### PR TITLE
Fixed external links

### DIFF
--- a/admin-api/themes/uploading-a-theme.mdx
+++ b/admin-api/themes/uploading-a-theme.mdx
@@ -2,9 +2,9 @@
 title: Uploading a theme
 ---
 
-To upload a theme ZIP archive, send a multipart formdata request by providing the `'Content-Type': 'multipart/form-data;'` header, along with the following field encoded as [FormData](https://developer.mozilla.org/en-US/Web/API/FormData/FormData):
+To upload a theme ZIP archive, send a multipart formdata request by providing the `'Content-Type': 'multipart/form-data;'` header, along with the following field encoded as [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData/FormData):
 
-`file`: *[Blob](https://developer.mozilla.org/en-US/Web/API/Blob) or [File](https://developer.mozilla.org/en-US/Web/API/File)* The theme archive that you want to upload.
+`file`: *[Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob) or [File](https://developer.mozilla.org/en-US/docs/Web/API/File)* The theme archive that you want to upload.
 
 <RequestExample>
 ```bash

--- a/changes.mdx
+++ b/changes.mdx
@@ -19,7 +19,7 @@ This is when any bugs or unexpected compatibility issues have been resolved but 
 
 ## Mobiledoc deprecation
 
-With the release of the [new editor](https://ghost.org/changelog/editor-beta/), Ghost uses [Lexical](https://lexical.dev/) to store post content, which replaces the previous format Mobiledoc. Transitioning to Lexical enables Ghost to build new powerful features that weren’t possible with Mobiledoc. To remain compatible with Ghost, integrations that rely on Mobiledoc should switch to using Lexical. [For more resources on working with Lexical, see their docs](https://lexical.dev/intro).
+With the release of the [new editor](https://ghost.org/changelog/editor-beta/), Ghost uses [Lexical](https://lexical.dev/) to store post content, which replaces the previous format Mobiledoc. Transitioning to Lexical enables Ghost to build new powerful features that weren’t possible with Mobiledoc. To remain compatible with Ghost, integrations that rely on Mobiledoc should switch to using Lexical. [For more resources on working with Lexical, see their docs](https://lexical.dev/docs/intro).
 
 ## Ghost 5.0
 

--- a/config.mdx
+++ b/config.mdx
@@ -618,7 +618,7 @@ With custom cache adapters, like Redis storage, the cache can expand its size in
 
 #### Ghost’s built-in Redis cache adapter
 
-Ghost’s built-in Redis cache adapter solves the downsides named above by persisting across Ghost restarts and not being limited by the Ghost instance’s RAM capacity. [Implementing a Redis cache](https://redis.io/getting-started/installation/,) is a good solution for sites with high load and complicated templates, ones using lots of `get` helpers. Note that this adapter requires Redis to be set up and running in addition to Ghost.
+Ghost’s built-in Redis cache adapter solves the downsides named above by persisting across Ghost restarts and not being limited by the Ghost instance’s RAM capacity. [Implementing a Redis cache](https://redis.io/docs/getting-started/installation/) is a good solution for sites with high load and complicated templates, ones using lots of `get` helpers. Note that this adapter requires Redis to be set up and running in addition to Ghost.
 
 To use the Redis cache adapter, change the value for the cache adapter from “Memory” to “Redis” in the site’s configuration file. In the following example, image sizes and the tags Content API endpoint are cached in Redis for optimized performance.
 
@@ -772,7 +772,7 @@ Tell Ghost how to treat [spam requests](https://github.com/TryGhost/Ghost/blob/f
 
 ### Caching
 
-Configure [HTTP caching](https://developer.mozilla.org/en-US/Web/HTTP/Caching) for HTTP responses served from Ghost.
+Configure [HTTP caching](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching) for HTTP responses served from Ghost.
 
 `caching` configuration is available for responses containing `public` value in `Cache-Control` header. Each key under `caching` section contains `maxAge` property that controls the `max-age` value in `Cache-Control` header. For example, the following configuration:
 
@@ -794,7 +794,7 @@ The following configuration keys are available with default `maxAge` values:
 * “sitemap” - with `"maxAge": 3600`, controls responses for `sitemap.xml` [files](https://ghost.org/changelog/xml-sitemaps/)
 * “sitemapXSL” - with `"maxAge": 86400`, controls responses for `sitemap.xsl` files
 * “wellKnown” - with `"maxAge": 86400`, controls responses coming from `*/.wellknown/*` endpoints
-* “cors” - with `"maxAge": 86400`, controls responses for `OPTIONS` [CORS](https://developer.mozilla.org/en-US/Web/HTTP/CORS) requests
+* “cors” - with `"maxAge": 86400`, controls responses for `OPTIONS` [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) requests
 * “publicAssets” - with `"maxAge": 31536000`, controls responses for public assets like `public/ghost.css`, `public/cards.min.js`, etc.
 * “301” - with `"maxAge": 31536000`, controls 301 redirect responses
 * “customRedirects” - with `"maxAge": 31536000`, controls redirects coming from [custom redirects](/themes/routing/#redirects)
@@ -825,7 +825,7 @@ The original image is kept with the suffix `_o`.
 
 When creating NFT embeds, Ghost fetches the information from the [OpenSea](https://opensea.io) API. This API is rate limited, and OpenSea request that you use an API key in production environments.
 
-You can [request an OpenSea API key](https://docs.opensea.io/reference/request-an-api-key) from them directly, without needing an account.
+You can [request an OpenSea API key](https://docs.opensea.io/reference/api-keys) from them directly, without needing an account.
 
 ```json
 "opensea": {

--- a/faq.mdx
+++ b/faq.mdx
@@ -30,7 +30,7 @@ Image uploads can be affected by the default max upload size of 50mb. If you nee
 </Card>
 
 <Card title="Mail config error in Ghost with Google Cloud" href="/faq/mail-config-error-google-cloud/">
-There’s a known issue that Google Cloud Platform does NOT allow any traffic on port 25 on a [Compute Engine instance](https://cloud.google.com/compute/tutorials/sending-mail/).
+There’s a known issue that Google Cloud Platform does NOT allow any traffic on port 25 on a [Compute Engine instance](https://cloud.google.com/compute/docs/tutorials/sending-mail/).
 </Card>
 
 <Card title="Major Versions & Long Term Support" href="/faq/major-versions-lts/">

--- a/faq/mail-config-error-google-cloud.mdx
+++ b/faq/mail-config-error-google-cloud.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Mail Config Error In Ghost With Google Cloud"
-description: There’s a known issue that Google Cloud Platform does NOT allow any traffic on port 25 on a [Compute Engine instance](https://cloud.google.com/compute/tutorials/sending-mail/).
+description: There’s a known issue that Google Cloud Platform does NOT allow any traffic on port 25 on a [Compute Engine instance](https://cloud.google.com/compute/docs/tutorials/sending-mail/).
 ---
 
 ***

--- a/install/digitalocean.mdx
+++ b/install/digitalocean.mdx
@@ -14,7 +14,7 @@ Digital Ocean the official hosting partner of the Ghost open source project, and
 For this install there are three things which you need to have ready up-front:
 
 1. A DigitalOcean account ([This signup link](https://m.do.co/c/9ff29836d717) will give you \$100 free credit)
-2. Your SSH key added to the account. [Follow these instructions](https://www.digitalocean.com/droplets/how-to/add-ssh-keys/to-account/)
+2. Your SSH key added to the account. [Follow these instructions](https://www.digitalocean.com/docs/droplets/how-to/add-ssh-keys/to-account/)
 3. A domain name to point at your new site (Mandatory for SSL configuration during install)
 
 ***

--- a/install/docker.mdx
+++ b/install/docker.mdx
@@ -12,4 +12,4 @@ Resources and downloads:
 * **[Installation steps](https://hub.docker.com/_/ghost/)**
 * [Ghost Docker Image on GitHub](https://github.com/docker-library/ghost)
 * [Reporting issues](https://github.com/docker-library/ghost/issues)
-* [Play With Docker direct link](http://play-with-docker.com/?stack=https://raw.githubusercontent.com/docker-library/e24f39cddf21560cf0a24f149059ff23640b0f16/ghost/stack.yml)
+* [Play With Docker direct link](http://play-with-docker.com/?stack=https://raw.githubusercontent.com/docker-library/docs/e24f39cddf21560cf0a24f149059ff23640b0f16/ghost/stack.yml)

--- a/install/linode.mdx
+++ b/install/linode.mdx
@@ -15,7 +15,7 @@ This install is **not** suitable for [local use](/install/local/) or [contributi
 
 The officially recommended production installation requires the following stack:
 
-* A [configured](https://www.linode.com/guides/getting-started/) and [secured](https://www.linode.com/guides/securing-your-server/) Linode server
+* A [configured](https://www.linode.com/docs/guides/getting-started/) and [secured](https://www.linode.com/docs/guides/securing-your-server/) Linode server
 * A server with at least 1GB memory
 
 ***
@@ -26,7 +26,7 @@ This part of the guide will ensure all prerequisites are met for installing the 
 
 ### Setup the server
 
-Follow the [official “Getting Started with Linode” guide](https://www.linode.com/guides/getting-started/) to setup your server. You must choose the **Ubuntu image** when creating your server. As you’re creating a new server you should prefer Ubuntu version 22.04 LTS. However you can use Ubuntu 20.04, 18.04 or 16.04 if you want.
+Follow the [official “Getting Started with Linode” guide](https://www.linode.com/docs/guides/getting-started/) to setup your server. You must choose the **Ubuntu image** when creating your server. As you’re creating a new server you should prefer Ubuntu version 22.04 LTS. However you can use Ubuntu 20.04, 18.04 or 16.04 if you want.
 
 <Note>
    Note: Using the user name `ghost` causes conflicts with the Ghost-CLI, so it’s important to use an alternative name.
@@ -34,7 +34,7 @@ Follow the [official “Getting Started with Linode” guide](https://www.linode
 
 ### Secure your server
 
-Follow the [official “How to Secure Your Server” Linode guide](https://www.linode.com/guides/securing-your-server/) to secure your server.
+Follow the [official “How to Secure Your Server” Linode guide](https://www.linode.com/docs/guides/securing-your-server/) to secure your server.
 
 ### Install Ghost on Ubuntu
 

--- a/install/local.mdx
+++ b/install/local.mdx
@@ -19,7 +19,7 @@ To install Ghost locally you will need the following:
 
 * A computer running MacOS, Windows or Linux
 * A [supported version](/faq/node-versions/) of [Node.js](https://nodejs.org)
-* Either [yarn](https://yarnpkg.com/en/install#alternatives-tab) or [npm](https://www.npmjs.com/get-npm) to manage packages
+* Either [yarn](https://yarnpkg.com/en/docs/install#alternatives-tab) or [npm](https://www.npmjs.com/get-npm) to manage packages
 * A clean, empty directory on your machine
 
 ***

--- a/install/source.mdx
+++ b/install/source.mdx
@@ -10,7 +10,7 @@ sidebarTitle: "This guide is for installing a local development copy of Ghost fr
 Before getting started, you’ll need these global packages to be installed:
 
 * **A [supported version](/faq/node-versions/) of [Node.js](https://nodejs.org)** - Ideally installed via [nvm](https://github.com/creationix/nvm#install-script)
-* **[Yarn](https://yarnpkg.com/en/install#alternatives-tab)** - to manage all the packages
+* **[Yarn](https://yarnpkg.com/en/docs/install#alternatives-tab)** - to manage all the packages
 * **Docker (ie. [Docker Desktop](https://www.docker.com/products/docker-desktop/))** - to run the MySQL database and other services
 
 ***

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -135,7 +135,7 @@ Ghost will automatically generate and link to a complete Google sitemap includin
 
 **Automatic structured data \+ JSON-LD**
 
-Ghost generates [JSON-LD](https://developers.google.com/search/guides/intro-structured-data) based structured metadata about your pages so that you don’t have to rely on messy microformats in your markup to provide semantic context. Even if you change theme or front-end, your SEO remains perfectly intact. Ghost also adds automatic code for Facebook OpenGraph and Twitter Cards.
+Ghost generates [JSON-LD](https://developers.google.com/search/docs/guides/intro-structured-data) based structured metadata about your pages so that you don’t have to rely on messy microformats in your markup to provide semantic context. Even if you change theme or front-end, your SEO remains perfectly intact. Ghost also adds automatic code for Facebook OpenGraph and Twitter Cards.
 
 **Canonical tags**
 

--- a/jamstack/eleventy.mdx
+++ b/jamstack/eleventy.mdx
@@ -25,7 +25,7 @@ To begin, create a new project by either cloning the [Eleventy Starter Ghost rep
 git clone git@github.com:TryGhost/eleventy-starter-ghost.git
 ```
 
-Navigate into the newly created project and use the command `yarn` to install the dependencies. Check out the official documentation on how to install[Yarn](https://yarnpkg.com/en/docs/install#mac-stable).
+Navigate into the newly created project and use the command `yarn` to install the dependencies. Check out the official documentation on how to install [Yarn](https://yarnpkg.com/en/docs/install#mac-stable).
 
 To test everything installed correctly, use the following command to run your project:
 

--- a/jamstack/eleventy.mdx
+++ b/jamstack/eleventy.mdx
@@ -25,7 +25,7 @@ To begin, create a new project by either cloning the [Eleventy Starter Ghost rep
 git clone git@github.com:TryGhost/eleventy-starter-ghost.git
 ```
 
-Navigate into the newly created project and use the command `yarn` to install the dependencies. Check out the official documentation on how to install[Yarn](https://yarnpkg.com/en/install#mac-stable).
+Navigate into the newly created project and use the command `yarn` to install the dependencies. Check out the official documentation on how to install[Yarn](https://yarnpkg.com/en/docs/install#mac-stable).
 
 To test everything installed correctly, use the following command to run your project:
 
@@ -67,7 +67,7 @@ More information can be found on the [Content API documentation](/content-api/#k
 
 ## Next steps
 
-[The official Eleventy docs](https://www.11ty.io/)is a great place to learn more about how Eleventy works and how it can be used to build static sites.
+[The official Eleventy docs](https://www.11ty.io/docs)is a great place to learn more about how Eleventy works and how it can be used to build static sites.
 
 There’s also a guide for setting up a new static site, such as Eleventy,[with the hosting platform Netlify](/integrations/netlify/) so Netlify can listen for updates on a Ghost site and rebuild the static site.
 
@@ -77,7 +77,7 @@ For community led support about linking and building a Ghost site with Eleventy,
 
 *Here are a few common examples of using the Ghost Content API within an Eleventy project.*\*
 
-Retrieving data from the Content API within an Eleventy project is pretty similar to using the API in a JavaScript application. However there are a couple of conventions and techniques that will make the data easier to access when creating template files. The majority of these examples are intended to be placed in the `.eleventy.js` file in the root of the project, to find out more on configuring Eleventy refer to [their official documentation](https://www.11ty.io/config/).
+Retrieving data from the Content API within an Eleventy project is pretty similar to using the API in a JavaScript application. However there are a couple of conventions and techniques that will make the data easier to access when creating template files. The majority of these examples are intended to be placed in the `.eleventy.js` file in the root of the project, to find out more on configuring Eleventy refer to [their official documentation](https://www.11ty.io/docs/config/).
 
 ## Initialising the Content API
 
@@ -95,10 +95,10 @@ const api = new ghostContentAPI({
 
 ## Retrieving posts
 
-This example retrieves posts from the API and adds them as a new [collection to Eleventy](https://www.11ty.io/collections/). The example also performs some sanitisation and extra meta information to each post:
+This example retrieves posts from the API and adds them as a new [collection to Eleventy](https://www.11ty.io/docs/collections/). The example also performs some sanitisation and extra meta information to each post:
 
 * Adding tag and author meta information to each post
-* Converting post date to a [JavaScript date object](https://developer.mozilla.org/en-US/Web/JavaScript/Reference/Global_Objects/Date) for easier manipulation in templates
+* Converting post date to a [JavaScript date object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) for easier manipulation in templates
 * Bring featured posts to the top of the list
 
 ```js
@@ -128,7 +128,7 @@ This code fetches **all** posts because Eleventy creates the HTML files when the
 
 ## Retrieving posts by tag
 
-You’ll often want a page that shows all the posts that are marked with a particular tag. This example creates an [Eleventy collection](https://www.11ty.io/collections/) for the tags within a Ghost site, as well as attaching all the posts that are related to that tag:
+You’ll often want a page that shows all the posts that are marked with a particular tag. This example creates an [Eleventy collection](https://www.11ty.io/docs/collections/) for the tags within a Ghost site, as well as attaching all the posts that are related to that tag:
 
 ```js
 config.addCollection("tags", async function(collection) {
@@ -168,7 +168,7 @@ config.addCollection("tags", async function(collection) {
 
 ## Retrieving site settings
 
-We used this example within our [Eleventy Starter](https://github.com/TryGhost/eleventy-starter-ghost), but rather than putting this in the main configuration file it’s better to add it to a [Data file](https://www.11ty.io/data/), which partitions it from other code and allows it to be attached to a global variable like `site`.
+We used this example within our [Eleventy Starter](https://github.com/TryGhost/eleventy-starter-ghost), but rather than putting this in the main configuration file it’s better to add it to a [Data file](https://www.11ty.io/docs/data/), which partitions it from other code and allows it to be attached to a global variable like `site`.
 
 ```js
 module.exports = async function() {
@@ -190,4 +190,4 @@ All the examples above use asynchronous functions when getting data from the Con
 
 ## Next steps
 
-Check out our documentation on the [Content API Client Library](/content-api/javascript/) to see what else is possible, many of the examples there overlap with the examples above. [The official Eleventy docs site](https://www.11ty.io/)is very extensive as well if you wish to delve deeper into the API.
+Check out our documentation on the [Content API Client Library](/content-api/javascript/) to see what else is possible, many of the examples there overlap with the examples above. [The official Eleventy docs site](https://www.11ty.io/docs)is very extensive as well if you wish to delve deeper into the API.

--- a/jamstack/gatsby.mdx
+++ b/jamstack/gatsby.mdx
@@ -15,7 +15,7 @@ One of the best ways to start a new Gatsby site is with a Gatsby Starter, and in
 
 #### Prerequisites
 
-To use Gatsby Starters, and indeed Gatsby itself, the [Gatsby CLI](https://www.gatsbyjs.org/quick-start/) tool is required. Additionally, a [Ghost account](/pricing/) is needed to source content and get site related credentials.
+To use Gatsby Starters, and indeed Gatsby itself, the [Gatsby CLI](https://www.gatsbyjs.com/docs/quick-start/) tool is required. Additionally, a [Ghost account](/pricing/) is needed to source content and get site related credentials.
 
 #### Getting started
 
@@ -25,7 +25,7 @@ To begin, generate a new project using the [Gatsby Starter Ghost](https://github
 gatsby new my-gatsby-site https://github.com/TryGhost/gatsby-starter-ghost.git
 ```
 
-Navigate into the newly created project and use either npm install or yarn to install the dependencies. The Ghost team prefer to use [Yarn](https://yarnpkg.com/en/install#mac-stable).
+Navigate into the newly created project and use either npm install or yarn to install the dependencies. The Ghost team prefer to use [Yarn](https://yarnpkg.com/en/docs/install#mac-stable).
 
 Before customising and developing in this new Gatsby site, it’s wise to give it a test run to ensure everything is installed correctly. Use the following command to run the project:
 
@@ -67,7 +67,7 @@ Using [Netlify](https://www.netlify.com/) to host your site? If so, the `netlify
 
 ## Next steps
 
-[The official Gatsby docs](https://www.gatsbyjs.org/gatsby-project-structure/) is a great place to learn more about how typical Gatsby projects are structured and how it can be extended.
+[The official Gatsby docs](https://www.gatsbyjs.com/docs/gatsby-project-structure/) is a great place to learn more about how typical Gatsby projects are structured and how it can be extended.
 
 Gaining a greater understanding of how data and content can be sourced from the Ghost API with GraphQL will help with extending aforementioned starter project for more specific use cases.
 
@@ -75,7 +75,7 @@ There’s also a guide for setting up a new static site, such as Gatsby, [with t
 
 For community led support about linking and building a Ghost site with Gatsby, [visit the forum](https://forum.ghost.org/c/themes/).
 
-As with all content sources for Gatsby, content is fed in by [GraphQL](https://www.gatsbyjs.org/tutorial/part-four/), and it’s no different with Ghost. The official [Gatsby Source Ghost](https://github.com/TryGhost/gatsby-source-ghost) plugin allows you to pull content from your existing Ghost site.
+As with all content sources for Gatsby, content is fed in by [GraphQL](https://www.gatsbyjs.com/tutorial/part-four/), and it’s no different with Ghost. The official [Gatsby Source Ghost](https://github.com/TryGhost/gatsby-source-ghost) plugin allows you to pull content from your existing Ghost site.
 
 ## Getting started
 
@@ -173,13 +173,13 @@ The plugin doesn’t just work with Ghost - it’s compatible with an assortment
 
 With the ever expanding list of plugins available for Gatsby, it’s hard to understand which plugins are needed to make a high quality and well functioning site running on the Ghost API.
 
-[Gatsby Source Filesystem](https://www.gatsbyjs.org/packages/gatsby-source-filesystem/) is a plugin for creating additional directories inside a Gatsby site. This is ideal for storing static files (e.g. error pages), site-wide images, such as logos, and site configuration files like robots.txt.
+[Gatsby Source Filesystem](https://www.gatsbyjs.com/plugins/gatsby-source-filesystem/) is a plugin for creating additional directories inside a Gatsby site. This is ideal for storing static files (e.g. error pages), site-wide images, such as logos, and site configuration files like robots.txt.
 
-[Gatsby React Helmet plugin](https://www.gatsbyjs.org/packages/gatsby-plugin-react-helmet/) is very useful for constructing metadata in the head of any rendered page. The plugin requires minimum configuration, but can be modified to suit the need.
+[Gatsby React Helmet plugin](https://www.gatsbyjs.com/plugins/gatsby-plugin-react-helmet/) is very useful for constructing metadata in the head of any rendered page. The plugin requires minimum configuration, but can be modified to suit the need.
 
 ## Further reading
 
-There is plenty of reference material and resources on the [official Gatsby site](https://www.gatsbyjs.org/tutorial/), along with a long list of [available plugins](https://www.gatsbyjs.org/plugins/). It may also be worth understanding the underlying concepts of [static sites](https://jamstack.org/) and how they work differently to other sites.
+There is plenty of reference material and resources on the [official Gatsby site](https://www.gatsbyjs.com/tutorial/), along with a long list of [available plugins](https://www.gatsbyjs.com/plugins/). It may also be worth understanding the underlying concepts of [static sites](https://jamstack.org/) and how they work differently to other sites.
 
 To get an even more boarder view of performant site development check out web.dev from Google, which explores many topics on creating site for the modern web.
 
@@ -187,7 +187,7 @@ To get an even more boarder view of performant site development check out web.de
 
 Here are a few common examples of using GraphQL to query the Ghost API.
 
-Gatsby uses [GraphQL](https://www.gatsbyjs.org/graphql/) to retrieve content, retrieving content from the Ghost API is no different thanks to the Gatsby Source Ghost plugin. Below are some recipes to retrieve chunks of data from the API that you can use and manipulate for your own needs. More extensive learning can be found in the official [GraphQL documentation](https://graphql.org/graphql-js/passing-arguments/).
+Gatsby uses [GraphQL](https://www.gatsbyjs.com/docs/graphql/) to retrieve content, retrieving content from the Ghost API is no different thanks to the Gatsby Source Ghost plugin. Below are some recipes to retrieve chunks of data from the API that you can use and manipulate for your own needs. More extensive learning can be found in the official [GraphQL documentation](https://graphql.org/graphql-js/passing-arguments/).
 
 ## Retrieving posts
 

--- a/jamstack/gridsome.mdx
+++ b/jamstack/gridsome.mdx
@@ -114,7 +114,7 @@ This code renames the GraphQL identifiers in the Gridsome starter of `descriptio
 
 ### Single post page
 
-Templates in Gridsome follow a [specific naming convention](https://gridsome.org/templates) which uses the type names as defined in the GraphQL schema, so the existing `Post.vue` file in `/src/templates/` needs to be renamed to `GhostPost.vue`.
+Templates in Gridsome follow a [specific naming convention](https://gridsome.org/docs/templates) which uses the type names as defined in the GraphQL schema, so the existing `Post.vue` file in `/src/templates/` needs to be renamed to `GhostPost.vue`.
 
 Once this is done, replace the `<page-query>` section in the template with the following:
 

--- a/jamstack/hexo.mdx
+++ b/jamstack/hexo.mdx
@@ -27,11 +27,11 @@ hexo init my-hexo-site
 
 Running the Hexo site locally can be done by running `hexo server` and navigating to `http://localhost:4000/` in a web browser.
 
-More information on setting up and creating a Hexo site can be found on [the official Hexo site](https://hexo.io/setup).
+More information on setting up and creating a Hexo site can be found on [the official Hexo site](https://hexo.io/docs/setup).
 
 ## Getting started
 
-Firstly, create a new JavaScript file within a `scripts` folder at the root of the project directory, for example `./scripts/ghost.js` . Any script placed in the scripts folder acts like a Hexo script plugin, you can find out more about the [Plugins API in the Hexo documentation](https://hexo.io/plugins).
+Firstly, create a new JavaScript file within a `scripts` folder at the root of the project directory, for example `./scripts/ghost.js` . Any script placed in the scripts folder acts like a Hexo script plugin, you can find out more about the [Plugins API in the Hexo documentation](https://hexo.io/docs/plugins).
 
 Next, install the official [JavaScript Ghost Content API](/content-api/javascript/#installation) helper using:
 
@@ -258,6 +258,6 @@ The `author.slug` includes `/authors/` in the string so it correlates with [the 
 
 ## Further reading
 
-We highly recommend reading into the [official Hexo documentation](https://hexo.io/) for more info on how pages are generated. There’s also a handy [Troubleshooting page](https://hexo.io/troubleshooting.html) for any common issues encountered.
+We highly recommend reading into the [official Hexo documentation](https://hexo.io/docs) for more info on how pages are generated. There’s also a handy [Troubleshooting page](https://hexo.io/docs/troubleshooting.html) for any common issues encountered.
 
 Additionally there’s [plenty of themes for Hexo](https://hexo.io/themes/) that might be a good place to start when creating a custom Hexo site.

--- a/jamstack/next.mdx
+++ b/jamstack/next.mdx
@@ -48,7 +48,7 @@ Install the official [JavaScript Ghost Content API](/content-api/javascript/#ins
 yarn add @tryghost/content-api
 ```
 
-Once the helper is installed it can be added to the `posts.js` file using a [static `import` statement](https://developer.mozilla.org/en-US/Web/JavaScript/Reference/Statements/import):
+Once the helper is installed it can be added to the `posts.js` file using a [static `import` statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import):
 
 ```js
 import GhostContentAPI from "@tryghost/content-api";
@@ -97,7 +97,7 @@ Using an asynchronous function means Next.js will wait until all the content has
 
 ### Rendering posts
 
-Since you’re sending content from Ghost to a React application, data is passed to pages and components with [`props`](https://reactjs.org/components-and-props.html). Next.js extends upon that concept with [`getStaticProps`](https://nextjs.org/basic-features/data-fetching#getstaticprops-static-generation). This function will load the Ghost site content into the page before it’s rendered in the browser.
+Since you’re sending content from Ghost to a React application, data is passed to pages and components with [`props`](https://react.dev/learn/passing-props-to-a-component). Next.js extends upon that concept with [`getStaticProps`](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-static-props). This function will load the Ghost site content into the page before it’s rendered in the browser.
 
 Use the following to import the `getPosts` function created in previous steps within a page you want to render Ghost posts:
 
@@ -157,7 +157,7 @@ export async function getSinglePost(postSlug) {
 
 This function accepts a single `postSlug` parameter, which will be passed down by the template file using it. The page slug can then be used to query the Ghost Content API and get the associated post data back.
 
-Next.js provides [dynamic routes](https://nextjs.org/routing/dynamic-routes) for pages that don’t have a fixed URL / slug. The name of the js file will be the variable, in this case the post `slug`, wrapped in square brackets – `[slug].js`.
+Next.js provides [dynamic routes](https://nextjs.org/docs/routing/dynamic-routes) for pages that don’t have a fixed URL / slug. The name of the js file will be the variable, in this case the post `slug`, wrapped in square brackets – `[slug].js`.
 
 The `getSinglePost()` function can be used within the `[slug].js` file like so:
 
@@ -229,7 +229,7 @@ const IndexPage = (props) => (
 );
 ```
 
-Pages are linked in this fashion within Next.js applications to make full use of client-side rendering as well as server-side rendering. To read more about how the `Link` component works and it’s use within Next.js apps [check out their documentation](https://nextjs.org/api-reference/next/link).
+Pages are linked in this fashion within Next.js applications to make full use of client-side rendering as well as server-side rendering. To read more about how the `Link` component works and it’s use within Next.js apps [check out their documentation](https://nextjs.org/docs/pages/api-reference/components/link).
 
 ## Examples
 

--- a/jamstack/vuepress.mdx
+++ b/jamstack/vuepress.mdx
@@ -381,4 +381,4 @@ Restart your server and head to http\://localhost:8080/ to see the posts being r
 
 ### Further reading
 
-Learn more about the Ghost API and specific endpoints in our [API documentation](/content-api/) or check out the VuePress docs to find out [how to customize the default theme](https://vuepress.vuejs.org/theme/default-theme-config.html).
+Learn more about the Ghost API and specific endpoints in our [API documentation](/content-api/) or check out the VuePress docs to find out [how to customize the default theme](https://vuepress.vuejs.org/guide/theme.html).

--- a/recommendations.mdx
+++ b/recommendations.mdx
@@ -20,7 +20,7 @@ The sections below provide a high-level technical summary of how recommendations
 
 * The recommendations modal is shown automatically whenever a new member subscribes to a Ghost publication.
 * Visiting `https://yoursite.com/#/portal/recommendations` will open the recommendations modal. Use this URL as a link in the navigation menu to create a recommendation button.
-* See additional methods for opening the recommendations modal in our [theme docs](/themes/helpers/recommendations/).
+* See additional methods for opening the recommendations modal in our [theme docs](/themes/helpers/data/recommendations/).
 
 ## How Ghost sends a recommendation
 

--- a/themes/contexts/error.mdx
+++ b/themes/contexts/error.mdx
@@ -5,7 +5,7 @@ description: Error templates used for all `4xx` and `5xx` errors that may arise 
 
 ***
 
-The most common errors seen in Ghost are `404` errors. Depending on the complexity of your theme, your [routes file](/themes/routing/) and other factors, errors can range from `4xx` to `5xx`. Read more about error [status codes on MDN](https://developer.mozilla.org/en-US/Web/HTTP/Status).
+The most common errors seen in Ghost are `404` errors. Depending on the complexity of your theme, your [routes file](/themes/routing/) and other factors, errors can range from `4xx` to `5xx`. Read more about error [status codes on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status).
 
 ## Routes
 

--- a/themes/helpers/data/date.mdx
+++ b/themes/helpers/data/date.mdx
@@ -14,7 +14,7 @@ description: 'Usage: `{{date value format="formatString"}}`'
 {{date published_at format="MMMM DD, YYYY"}}
 ```
 
-See the [Moment.js Display tokens](https://momentjs.com/#/displaying/format/) for more options.
+See the [Moment.js Display tokens](https://momentjs.com/docs/#/displaying/format/) for more options.
 
 Timezone and locale may be overridden from your site’s defaults by passing the `timezone` and `locale` parameters:
 

--- a/themes/helpers/data/link.mdx
+++ b/themes/helpers/data/link.mdx
@@ -21,7 +21,7 @@ Will output:
 <a href="/about/">..linked content here..</a>
 ```
 
-All attributes associated with the `<a></a>` element can be used in `{{#link}}`. Check out the MDN documentation on [the anchor element for more information](https://developer.mozilla.org/en-US/Web/HTML/Element/a).
+All attributes associated with the `<a></a>` element can be used in `{{#link}}`. Check out the MDN documentation on [the anchor element for more information](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a).
 
 ## Variables
 

--- a/themes/members.mdx
+++ b/themes/members.mdx
@@ -373,7 +373,7 @@ Members may have multiple subscriptions, provided as an array. Subscription data
 
 ### Subscription attributes
 
-Subscription data comes from Stripe meaning a valid Stripe account connected to Ghost is required. Using subscription data in a local environment requires the [Stripe CLI tool](https://stripe.com/stripe-cli).
+Subscription data comes from Stripe meaning a valid Stripe account connected to Ghost is required. Using subscription data in a local environment requires the [Stripe CLI tool](https://stripe.com/docs/stripe-cli).
 
 * `id` –The Stripe ID of the subscription
 * `avatar_image` — The customers avatar image, pulled in from [Gravatar](https://en.gravatar.com/). If there is not one set for their email a transparent `png` will be returned as a default

--- a/trademark.mdx
+++ b/trademark.mdx
@@ -1,0 +1,4 @@
+---
+title: "Trademark"
+url: "https://ghost.org/trademark"
+---

--- a/webhooks.mdx
+++ b/webhooks.mdx
@@ -55,7 +55,7 @@ Currently Ghost has support for below events on which webhook can be setup:
 
 Webhooks allow Ghost to communicate with Stripe. In order to use Stripe with a local version of Ghost you’ll need to do some additional setup to allow webhook events happen between Stripe and Ghost.
 
-First, follow the instructions on [how to install and log into the Stripe CLI tool](https://stripe.com/stripe-cli) in the Stripe documentation.
+First, follow the instructions on [how to install and log into the Stripe CLI tool](https://stripe.com/docs/stripe-cli) in the Stripe documentation.
 
 Then, before starting a local instance of Ghost, run the following command in your CLI. Note that the localhost port number should match the one used in your local Ghost install:
 


### PR DESCRIPTION
no issue

- removing `docs/` took it out of external links too, this fixes that
- updates a few sites that've changed their routes a bit, like Gatsby
- adds trademark page, which links directly to ghost.org/trademark