### PR TITLE
Increase the contrast of inline code elements

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,0 +1,8 @@
+/* Increase the contrast of inline code elements */
+.prose :not(pre)>code {
+    background-color: rgb(var(--primary)/.1);
+}
+
+.prose :not(pre)>code:is(.dark *) {
+    background-color: rgb(var(--primary-light)/.1);
+}


### PR DESCRIPTION
I think that the inline code elements lack contrast. We can add custom CSS with Mintlify by adding `style.css` to the root, so I've created that file and used the same pattern as the theme uses for the background color, but with less opacity. 

## Before:

<img width="2198" height="888" alt="light-before" src="https://github.com/user-attachments/assets/01615149-7a0e-4fae-bb15-3e821606b683" />
<img width="2234" height="878" alt="dark-before" src="https://github.com/user-attachments/assets/b64bef0f-1f76-440b-b725-915b2bdc64d2" />

## After:

<img width="2322" height="828" alt="after-light" src="https://github.com/user-attachments/assets/2ed79742-ed49-4a8f-8739-a2c9e1d7f5de" />
<img width="2194" height="872" alt="after-dark" src="https://github.com/user-attachments/assets/0b2c6ae4-6801-4d89-8613-48154c0427c3" />
