### PR TITLE
Remove markdown from bash command

### DIFF
--- a/update-major-version.mdx
+++ b/update-major-version.mdx
@@ -31,7 +31,7 @@ Run `node -v` to check your node version.
 If less than 22, update node:
 
 ```bash
-curl -fsSL [https://deb.nodesource.com/setup_22.x](https://deb.nodesource.com/setup_22.x) | sudo -E bash -
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
 
 sudo apt-get install -y nodejs
 ```


### PR DESCRIPTION
Copy-pasting the given command doesn't work because of some markdown formatting left inside. I've just removed the markdown formatting so copying the command now works.