### PR TITLE
Add missing "to" in local setup docs

### DIFF
--- a/install/local.mdx
+++ b/install/local.mdx
@@ -101,6 +101,6 @@ GScan can also be accessed at [gscan.ghost.org](https://gscan.ghost.org/), where
 
 You’ve completed a local Ghost install — congrats! You can now put Ghost through its paces and see what it’s all about, or jump right into developing a custom Ghost theme.
 
-When you’re ready ship your site to production, [follow one of these guides](/install/).
+When you’re ready to ship your site to production, [follow one of these guides](/install/).
 
 For more information about theme development read the [Handlebars theme documentation](/themes/) and check out the [tutorials](https://ghost.org/tutorials/).


### PR DESCRIPTION
There's a word missing at the bottom of [this page](https://docs.ghost.org/install/local).

This PR fixes that and makes the whole sentence grammatically correct.
