### PR TITLE
Add database and content folder backup instructions

### DIFF
--- a/faq/manual-backup.mdx
+++ b/faq/manual-backup.mdx
@@ -5,11 +5,80 @@ description: Learn how to backup your self-hosted Ghost install
 
 ***
 
-When performing manual updates it’s always recommended to make a full backup of your site first, so if anything goes wrong, you’ll still have all your data.
+When performing manual updates it's always recommended to make a full backup of your site first, so if anything goes wrong, you'll still have all your data.
+
+## Using Ghost CLI backup
 
 The fastest way to perform a backup is to use Ghost CLI to automatically generate a zip file containing all of your site data using the `ghost backup` command.
 
-If you need to perform a manual backup of your data, the following guide walks you through all of the steps.
+## Manual backup methods
+
+If you need more control over your backups, or need to back up a Docker installation, the following sections explain how to manually back up different parts of your Ghost site.
+
+<Note>
+**What's included:** JSON exports are great for moving content between sites, but don't include email analytics, member engagement data, or comments. For disaster recovery or exact site replication, back up your database and content folder directly.
+</Note>
+
+### Database backup
+
+**For Docker installations:**
+
+```bash
+# Create a backup directory
+mkdir -p ~/ghost-backups
+
+# List containers to find your MySQL container
+docker ps
+
+# Export the database
+docker exec MYSQL_CONTAINER_NAME mysqldump -u root -p ghost > ~/ghost-backups/ghost_backup.sql
+```
+
+**For standard Ghost CLI installations:**
+
+```bash
+# Create a backup directory
+mkdir -p ~/ghost-backups
+
+# Export the database (credentials are in config.production.json)
+mysqldump -u ghost_user -p ghost_production > ~/ghost-backups/ghost_backup.sql
+```
+
+### Content folder backup
+
+**For Docker installations:**
+
+```bash
+# Find your Ghost volume
+docker volume ls
+
+# Create a backup using a temporary container
+docker run --rm \
+  -v ghost_ghost_data:/ghost_content \
+  -v ~/ghost-backups:/backup \
+  alpine \
+  tar czf /backup/ghost_content_backup.tar.gz -C /ghost_content .
+```
+
+**For standard Ghost CLI installations:**
+
+```bash
+# Create a compressed backup of content
+cd /var/www/ghost
+tar czf ~/ghost-backups/ghost_content_backup.tar.gz content/
+```
+
+### Download to local machine
+
+```bash
+# Using rsync
+rsync -av your_username@your_server:~/ghost-backups/ ./ghost-backups/
+
+# Or using scp
+scp -r your_username@your_server:~/ghost-backups/ ./ghost-backups/
+```
+
+***
 
 ### Export content
 
@@ -57,7 +126,50 @@ Export all members in one CSV file from the Members dashboard in Ghost Admin.
 
 ## Restoring your data from a manual backup
 
-The following steps explain how to restore data from a manual backup.
+### Restoring database and content backups
+
+If you backed up your MySQL database and content folder, follow these steps to restore them:
+
+**For Docker installations:**
+
+```bash
+# Stop Ghost
+docker stop GHOST_CONTAINER_NAME
+
+# Restore the database
+docker exec -i MYSQL_CONTAINER_NAME mysql -u root -p ghost < ~/ghost-backups/ghost_backup.sql
+
+# Restore the content folder
+docker run --rm \
+  -v ghost_ghost_data:/ghost_content \
+  -v ~/ghost-backups:/backup \
+  alpine \
+  tar xzf /backup/ghost_content_backup.tar.gz -C /ghost_content
+
+# Start Ghost
+docker start GHOST_CONTAINER_NAME
+```
+
+**For standard Ghost CLI installations:**
+
+```bash
+# Stop Ghost
+cd /var/www/ghost
+ghost stop
+
+# Restore the database
+mysql -u ghost_user -p ghost_production < ~/ghost-backups/ghost_backup.sql
+
+# Restore the content folder
+cd /var/www/ghost
+tar xzf ~/ghost-backups/ghost_content_backup.tar.gz
+
+# Fix permissions
+sudo chown -R ghost:ghost content
+
+# Restart Ghost
+ghost start
+```
 
 ### Copy images, files and media
 


### PR DESCRIPTION
Enhance backup docs with MySQL and content folder backup methods for Docker and Ghost CLI installations. Includes restoration procedures and clarifies that JSON exports don't contain analytics or comments.

---

Got a PR for us? Awesome 🎊!

Please take a minute to explain the change you're proposing:

**Why are you making it?**
The current backup documentation focuses primarily on JSON exports, which don't include email analytics, member engagement data, or comments. Users who need complete 1:1 site restoration need to back up the MySQL database and content folder directly. This gap in documentation is a common question in the forum and on Reddit.
 
**What does it do?**
Adds instructions for backing up and restoring MySQL databases and content folders for both Docker and Ghost CLI installations. Includes a note about JSON export limitations and integrates these backup methods into the existing manual backup guide structure.

**Why is this something Ghost users or developers need?**
Production Ghost sites need reliable disaster recovery procedures. Without database backups, users lose newsletter analytics, comments, and member engagement data. This provides users with production-grade backup strategies that work alongside the existing `ghost backup` CLI command.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds manual MySQL database and content folder backup/restore steps for Docker and Ghost CLI, plus a note clarifying JSON export limitations.
> 
> - **Docs (faq/manual-backup.mdx)**:
>   - **Manual backup methods**:
>     - Add database backup instructions:
>       - Docker: `mysqldump` via `docker exec`.
>       - Ghost CLI installs: `mysqldump` using `config.production.json` creds.
>     - Add content folder backup instructions:
>       - Docker: archive volume with temporary container and `tar`.
>       - Ghost CLI installs: `tar` the `content/` directory.
>     - Add download-to-local examples using `rsync` and `scp`.
>     - Insert note clarifying JSON exports exclude analytics, engagement, and comments.
>   - **Restoration procedures**:
>     - Docker: stop container, restore MySQL dump and content archive, restart.
>     - Ghost CLI installs: stop Ghost, restore MySQL and content, fix permissions, start Ghost.
>   - Minor text tweaks (straight quotes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 743edb4c6f654d4ede319cbc024cdbce23cc710f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->