### PR TITLE
Refactor split helper documentation for clarity

### DIFF
--- a/themes/helpers/utility/split.mdx
+++ b/themes/helpers/utility/split.mdx
@@ -1,13 +1,13 @@
 ---
 title: "split"
-description: 'Usage: `{{split "apple-banana-pear" separator="-"}}`'
+description: 'Usage: `{{#split "apple-banana-pear" separator="-"}}`'
 ---
 
 ***
 
-The `{{split}}` helper is designed to split a string into separate strings.  It can be used in block or inline mode.
+The `{{#split}}` helper is designed to split a string into separate strings.  It can be used in block or inline mode.
 
-The `{{split}}` helper returns an array, suitable for iteration with `{{#foreach}}`, with individual elements of the array suitable for any helper that expects a string.
+The `{{#split}}` helper returns an array, suitable for iteration with `{{#foreach}}`, with individual elements of the array suitable for any helper that expects a string.
 
 Individual elements of the array may be addressed as `{{this}}` within a `{{#foreach}}` loop.
 
@@ -25,7 +25,7 @@ Outputs:
 
 |hello||world|
 ```
-
+### Inline mode:
 ```handlebars
 {{#foreach (split "hello, world" separator=",")}}
    {{this}} {{#unless @last}}<br>{{/unless}}
@@ -38,6 +38,7 @@ hello<br> world
 
 `{{split}}` is designed for strings. If it receives a non-string, it attempts to convert it to a string first.
 
+
 ## The separator attribute
 
 By default, strings are split at each ",". The `separator=""` attribute allows settings the split location to an arbitrary value.
@@ -45,6 +46,7 @@ By default, strings are split at each ",". The `separator=""` attribute allows s
 Passing an empty string for the separator results in splitting to single characters.
 
 Separators may be multiple characters.
+
 
 ### Additional examples
 
@@ -78,3 +80,20 @@ from-my-slug
 {{/foreach}}
 ```
 
+
+### No empty strings
+Split filters the array to exclude any empty strings from the final result.  Sequential separators will not result in empty strings.
+
+```handlebars
+{{#foreach (split ",banana,,apple,")}}
+  {{#unless @first}}{{#unless @last}}-{{/unless}}{{/unless}}{{#unless @last}}
+    ({{this}})
+  {{/unless}}
+{{/foreach}}
+
+Outputs: 
+
+(banana)(apple)
+
+Not: ()(banana)()(apple)() 
+```


### PR DESCRIPTION
Updated the usage syntax for the split helper from `{{split}}` to `{{#split}}` and added additional examples for clarity, clarifying the behavior for empty strings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `split` helper docs to use `{{#split}}`, adds inline usage example, and documents filtering of empty strings.
> 
> - **Docs: `themes/helpers/utility/split.mdx`**
>   - Update usage and references from `{{split}}` to `{{#split}}`.
>   - Add **Inline mode** example using `{{#foreach (split ...)}}`.
>   - Document behavior: filters out empty strings when separators are sequential, with example output.
>   - Expand examples for custom separators and iteration with `{{#foreach}}`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4b126976d39235cc0a239fc524f5f462c1cf420. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->