### PR TITLE
Fix typo in error message documentation

### DIFF
--- a/faq/python-setuptools-required-sqlite3.mdx
+++ b/faq/python-setuptools-required-sqlite3.mdx
@@ -7,7 +7,7 @@ description: Ghost local missing sqlite module due to Python & setuptools being 
 
 ### Error
 
-If you see etiher of these errors when using Ghost-CLI:
+If you see either of these errors when using Ghost-CLI:
 
 ```
 Python is required for SQLite3


### PR DESCRIPTION
Fix typo 'etiher' -> 'either'

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes a typo (“etiher” → “either”) in `faq/python-setuptools-required-sqlite3.mdx` Ghost-CLI error section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdf3a8b991b9004124f564cc7f45e44858d8ee9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->