### PR TITLE
fix: fixed button color contrast

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -20,7 +20,7 @@ description: Learn how to build and develop beautiful, independent publications
 <br className='hidden md:block'  />
 <p>Follow our setup guides for any platform, from local development to production environments.</p>
 <br />
-<a href="install/" className='p-2 rounded-md bg-primary text-light border border-primary dark:border-primary dark:bg-white dark:text-primary'>Get Started →</a>
+<a href="install/" className='p-2 rounded-md bg-primary text-white border border-primary dark:bg-primary dark:text-white dark:border-primary'>Get Started →</a>
 <br />
 <br />
 <div className='flex gap-3'>

--- a/index.mdx
+++ b/index.mdx
@@ -20,7 +20,7 @@ description: Learn how to build and develop beautiful, independent publications
 <br className='hidden md:block'  />
 <p>Follow our setup guides for any platform, from local development to production environments.</p>
 <br />
-<a href="install/" className='p-2 rounded-md bg-primary text-white border border-primary dark:bg-primary dark:text-white dark:border-primary'>Get Started →</a>
+<a href="install/" className='p-2 rounded-md bg-primary text-white border border-primary dark:bg-white dark:text-primary dark:border-white'>Get Started →</a>
 <br />
 <br />
 <div className='flex gap-3'>


### PR DESCRIPTION
The Button wasnt readable now the button color should be fixed

Got a PR for us? Awesome 🎊!

Please take a minute to explain the change you're proposing:

- Why are you making it? Fixing an error
- What does it do? Fix colors
- Why is this something Ghost users or developers need? Because its an ux error

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves color contrast of the homepage "Get Started" button for better readability, including dark mode adjustments.
> 
> - In `index.mdx`, updates the button classes from `text-light` to `text-white` and changes dark mode border from `dark:border-primary` to `dark:border-white` on the `Get Started →` link
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39b71c69a7551886ae238ca90bb9cbbe7906d1ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->