### PR TITLE
Fixed text on homepage button in dark mode

### DIFF
--- a/index.mdx
+++ b/index.mdx
@@ -20,7 +20,7 @@ description: Learn how to build and develop beautiful, independent publications
 <br className='hidden md:block'  />
 <p>Follow our setup guides for any platform, from local development to production environments.</p>
 <br />
-<a href="install/" className='p-2 rounded-md bg-primary text-white border border-primary dark:bg-white dark:text-primary dark:border-white'>Get Started →</a>
+<a href="install/" className='p-2 rounded-md bg-primary text-white border border-primary dark:bg-white dark:text-black dark:border-white'>Get Started →</a>
 <br />
 <br />
 <div className='flex gap-3'>

--- a/index.mdx
+++ b/index.mdx
@@ -20,7 +20,7 @@ description: Learn how to build and develop beautiful, independent publications
 <br className='hidden md:block'  />
 <p>Follow our setup guides for any platform, from local development to production environments.</p>
 <br />
-<a href="install/" className='p-2 rounded-md bg-primary text-white border border-primary dark:bg-white dark:text-black dark:border-white'>Get Started →</a>
+<a href="install/" className='p-2 rounded-md bg-primary text-white border border-primary dark:bg-white dark:text-[#15171A] dark:border-white'>Get Started →</a>
 <br />
 <br />
 <div className='flex gap-3'>


### PR DESCRIPTION
ref https://github.com/TryGhost/Docs/issues/25

- fixes the text for the Get Started button in dark mode on the home page

<img width="300" height="286" alt="Screenshot 2026-01-05 at 1 52 19 PM" src="https://github.com/user-attachments/assets/59d29f7e-2e40-44dc-80fe-639a45c51d43" />
