### PR TITLE
Update MySQL installation instructions for Ubuntu

### DIFF
--- a/install/ubuntu.mdx
+++ b/install/ubuntu.mdx
@@ -99,7 +99,16 @@ Next, you’ll need to install MySQL to be used as the production database.
 sudo apt-get install mysql-server
 ```
 
-On newer versions of Ubuntu, the root user created when you install MySQL will by default be configured to use socket-based authentication, meaning that only the root Unix user will be able to authenticate. Ghost does not support this kind of authentication, so you must change the root MySQL user to have a password. Run these commands to make the root user have a password:
+On newer versions of Ubuntu, the root user created when you install MySQL will by default be configured to use socket-based authentication, meaning that only the root Unix user will be able to authenticate. Ghost does not support this kind of authentication, so you must change the root MySQL user to have a password. 
+Also on newer mysql servers 'mysql_native_password' plugin are deprecated you will need to add the following to the mysql config to re-enable this plugin.
+```bash
+#add to /etc/mysql/*/mysql.cnf
+sudo vi /etc/mysql/mysql.conf.d/mysql.cnf
+[mysqld]
+mysql_native_password=ON
+```
+
+Run these commands to make the root user have a password:
 
 ```bash
 # Enter mysql


### PR DESCRIPTION
Added instructions to enable mysql_native_password plugin and set MySQL root user password.

Got a PR for us? Awesome 🎊!

Please take a minute to explain the change you're proposing:

- Why are you making it?
- What does it do?
- Why is this something Ghost users or developers need?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Ubuntu install docs for MySQL setup on newer servers.
> 
> - Adds steps to re-enable `mysql_native_password` in `/etc/mysql/mysql.conf.d/mysql.cnf` (`[mysqld] mysql_native_password=ON`)
> - Clarifies setting the MySQL `root` password using `ALTER USER ... IDENTIFIED WITH 'mysql_native_password'`
> - Minor formatting and newline fix
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dba5941d616f095e4ab7a1045037ed5bded89110. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->