### PR TITLE
Removed RPC Ping references

### DIFF
--- a/config.mdx
+++ b/config.mdx
@@ -385,7 +385,6 @@ All features inside the privacy.md file are enabled by default. It is possible t
 
 * Update check
 * Gravatar
-* RPC ping
 * Structured data
 
 For more information about the features, read the [privacy.md page](https://github.com/TryGhost/Ghost/blob/2f09dd888024f143d28a0d81bede1b53a6db9557/PRIVACY.md).
@@ -404,7 +403,6 @@ Alternatively, configure each feature individually:
 "privacy": {
     "useUpdateCheck": false,
     "useGravatar": false,
-    "useRpcPing": false,
     "useStructuredData": false
 }
 ```


### PR DESCRIPTION
As in Ghost v6.12.0, RPC Ping is removed. More information: https://github.com/TryGhost/Ghost/pull/25799

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns configuration docs with current behavior by removing deprecated RPC Ping references.
> 
> - Deletes `RPC ping` from the Privacy features list in `config.mdx`
> - Removes `"useRpcPing": false` from the per-feature `privacy` JSON example
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 452b2a0cea529254c0acea75f5b7aa5230e24fbb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->