### PR TITLE
Added card-level visibility explanation

### DIFF
--- a/admin-api/posts/card-visibility.mdx
+++ b/admin-api/posts/card-visibility.mdx
@@ -1,0 +1,63 @@
+---
+title: Card visibility
+---
+
+<Warning>
+If you're manipulating Lexical JSON directly (find-and-replace, content migration, programmatic editing), preserve the `visibility` property on cards. Stripping it resets cards to default visibility, which can unintentionally make members-only content public.
+</Warning>
+
+HTML and Call to Action cards support a `visibility` property that controls who sees that specific card. You can mix visibility within a single post, but card-level visibility only affects cards inside a post that the viewer can already access via the post's top-level `visibility`. This allows you to do things like: 
+- show premium content only to paid members
+- display an upgrade prompt only to free members
+- hide a sponsored block from paid subscribers
+
+A card with visibility controls looks like this:
+
+```json
+{
+    "type": "html",
+    "html": "<div>Premium analysis...</div>",
+    "visibility": {
+        "web": {
+            "nonMember": false,
+            "memberSegment": "status:-free"
+        },
+        "email": {
+            "memberSegment": "status:-free"
+        }
+    }
+}
+```
+
+The visibility object has two sub-objects:
+
+**`web`** — controls who sees the card on the website:
+- `nonMember` — `true` means visible to everyone including non-members; `false` means members only
+- `memberSegment` — NQL filter for which members can see it (e.g., `"status:free,status:-free"` for all members, `"status:-free"` for paid only)
+
+**`email`** — controls who sees the card in email delivery:
+- `memberSegment` — NQL filter for which members receive this card in emails
+
+When all visibility toggles are enabled (the default), the card is visible to everyone everywhere. A card with no `visibility` property behaves identically — fully visible.
+
+Here are some common configurations:
+
+```json Visible to all members (free and paid) on web, hidden from non-members
+{
+    "visibility": {
+        "web": { "nonMember": false, "memberSegment": "status:free,status:-free" },
+        "email": { "memberSegment": "status:free,status:-free" }
+    }
+}
+```
+
+```json Visible to paid members only
+{
+    "visibility": {
+        "web": { "nonMember": false, "memberSegment": "status:-free" },
+        "email": { "memberSegment": "status:-free" }
+    }
+}
+```
+
+Card-level visibility is a Lexical JSON feature. If you're sending content with source=html, Ghost creates cards automatically and visibility settings aren't available — work with Lexical JSON directly if you need them.

--- a/docs.json
+++ b/docs.json
@@ -189,7 +189,8 @@
                       "admin-api/posts/scheduling-a-post",
                       "admin-api/posts/sending-a-post",
                       "admin-api/posts/email-only-posts",
-                      "admin-api/posts/deleting-a-post"
+                      "admin-api/posts/deleting-a-post",
+                      "admin-api/posts/card-visibility"
                     ]
                   },
                   {


### PR DESCRIPTION
no ref

- Adds an explanation of how to add cards with different levels of visibility (paid-only etc) when creating posts in lexical via the API
- Found in the admin api docs, under Posts > Card Visibility

<img width="600" height="586" alt="Screenshot 2026-03-10 at 9 09 14 AM" src="https://github.com/user-attachments/assets/a83594f1-06fa-4f6a-939b-423d3c4c69d7" />


Quick spot check, referencing these docs to create a post via the API with various visibility settings
<img width="600" height="574" alt="Screenshot 2026-03-10 at 9 07 21 AM" src="https://github.com/user-attachments/assets/57a5099f-a653-4f11-8042-4c7de58fb151" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that adds a new page and navigation entry, with no runtime or API behavior changes.
> 
> **Overview**
> Adds a new Admin API docs page (`admin-api/posts/card-visibility`) explaining how to use the `visibility` property on HTML/CTA cards in Lexical JSON, including web/email options and example configurations (e.g., paid-only).
> 
> Updates `docs.json` navigation to include the new **Posts → Card visibility** page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66ec76f6884eb41b7f7329a40fe3433a64c5eb07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->