### PR TITLE
Replace obsolete mintlify CLI commands with mint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ mint dev --port 3333
 # Validate all reference links
 mint broken-links
 
-# Re-install dependencies if issues occur
+# Clear Mintlify local cache if you encounter local preview errors
 rm -rf ~/.mintlify && mint dev
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,22 +11,22 @@ This is a Mintlify documentation site that creates a modern documentation websit
 ### Development Setup
 ```bash
 # Install Mintlify CLI globally (required)
-npm i -g mintlify
+npm i -g mint
 
 # Start development server (default port 3000)
-mintlify dev
+mint dev
 
 # Start on custom port
-mintlify dev --port 3333
+mint dev --port 3333
 
 # Validate all reference links
-mintlify broken-links
+mint broken-links
 
 # Re-install dependencies if issues occur
-mintlify install
+rm -rf ~/.mintlify && mint dev
 ```
 
-**Note:** Requires Node.js version 19 or higher.
+**Note:** Requires Node.js v20.17.0 or higher.
 
 ## Architecture & Structure
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@ Official documentation for [Ghost](https://github.com/tryghost/ghost) - located 
 
 ### Development
 
+**Note:** Requires Node.js v20.17.0 or higher.
+
 Install Mintlify CLI to preview docs changes locally:
 
-```
+```bash
 npm i -g mint
 ```
 
 Start dev server with:
 
-```
+```bash
 mint dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Official documentation for [Ghost](https://github.com/tryghost/ghost) - located 
 Install Mintlify CLI to preview docs changes locally:
 
 ```
-npm i -g mintlify
+npm i -g mint
 ```
 
 Start dev server with:
 
 ```
-mintlify dev
+mint dev
 ```
 
 ---


### PR DESCRIPTION
This PR updates the README and CLAUDE markdown files to align with the current (as of 03/2026) Mintlify CLI command `mint` and Node.js requirements.

- Replace `mintlify` CLI with `mint` in README.md and CLAUDE.md, source: [Mintlify installation troubleshooting](https://www.mintlify.com/docs/installation#mintlify-versus-mint-package)
- Replace `mintlify install` with `rm -rf ~/.mintlify && mint dev`, source: [Mintlify installation troubleshooting](https://www.mintlify.com/docs/installation#issue-encountering-an-unknown-error)
- Update Node.js requirement from v19 to v20.17.0+, source: [Mintlify prerequisites](https://www.mintlify.com/docs/installation#prerequisites)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to local development commands and stated Node.js prerequisites; no runtime or production code changes.
> 
> **Overview**
> Updates contributor docs (`README.md` and `CLAUDE.md`) to use the current Mintlify CLI package/commands (`npm i -g mint`, `mint dev`, `mint broken-links`) instead of `mintlify`.
> 
> Refreshes local troubleshooting guidance by replacing `mintlify install` with clearing the local cache (`rm -rf ~/.mintlify`) and bumps the documented Node.js requirement to v20.17.0+.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58dcf91ae2d9d6a9251131e32af3f79a874f24c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->