### PR TITLE
Update themes.mdx

### DIFF
--- a/themes.mdx
+++ b/themes.mdx
@@ -14,7 +14,7 @@ Ghost also makes use of an additional library called `express-hbs` which adds so
 
 If you’ve previously built themes for other popular platforms, working with the Ghost theme layer is extremely accessible. This documentation gives you the tools required to create static HTML and CSS for a theme, using Handlebars expressions when you need to render dynamic data.
 
-Our tutorial on the [essential concepts to known when building a Ghost theme](https://ghost.org/tutorials/essential-concepts/), provides a fantastic introduction to everything you need to know to start building beautiful themes.
+Our tutorial on the [essential concepts to know when building a Ghost theme](https://ghost.org/tutorials/essential-concepts/), provides a fantastic introduction to everything you need to know to start building beautiful themes.
 
 ## Handlebars
 

--- a/themes.mdx
+++ b/themes.mdx
@@ -59,4 +59,4 @@ gscan -z /path/to/download/theme.zip
 
 That’s all of the background context required to get started. From here, take a look at the [structure](/themes/structure/) of Ghost themes and templates, and learn everything you need to know about the `package.json` file.
 
-For community led support about theme development, visit [the forum](https://forum.ghost.org/c/themes/).
+For community-led support about theme development, visit [the forum](https://forum.ghost.org/c/themes/).


### PR DESCRIPTION
corrected typo "concepts to knowN"

Got a PR for us? Awesome 🎊!

Please take a minute to explain the change you're proposing:

- Why are you making it?
- What does it do?
- Why is this something Ghost users or developers need?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; fixes a single typo and normalizes file ending with no runtime impact.
> 
> **Overview**
> Fixes a typo in `themes.mdx` (“concepts to known” → “concepts to know”) and ensures the file ends with a trailing newline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d1dd4f5530a067825bd78a9922a48824a6d5d50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->