### PR TITLE
Document {{#social_accounts}} block helper

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -117,6 +117,7 @@
                       "/themes/helpers/data/content",
                       "/themes/helpers/data/date",
                       "/themes/helpers/data/excerpt",
+                      "/themes/helpers/data/social_accounts",
                       "/themes/helpers/data/social_url",
                       "/themes/helpers/data/img_url",
                       "/themes/helpers/data/link",

--- a/themes/helpers/data.mdx
+++ b/themes/helpers/data.mdx
@@ -16,6 +16,7 @@ description: Data helpers are used to output data from your site. Use this refer
 | [content](/themes/helpers/data/content/)                         | Outputs the full post content as HTML                                |
 | [date](/themes/helpers/data/date/)                               | Outputs the date in a format of your choosing                        |
 | [excerpt](/themes/helpers/data/excerpt/)                         | Outputs the custom excerpt, or the post content with HTML stripped   |
+| [social\_accounts](/themes/helpers/data/social_accounts/)        | Iterates the connected social accounts on a site or author          |
 | [social\_url](/themes/helpers/data/social_url/)                  | Outputs the full URL to a social profile                             |
 | [img\_url](/themes/helpers/data/img_url/)                        | Outputs the correctly calculated URL for the provided image property |
 | [link](/themes/helpers/data/link/)                               | Creates links with dynamic classes                                   |

--- a/themes/helpers/data/social_accounts.mdx
+++ b/themes/helpers/data/social_accounts.mdx
@@ -95,7 +95,7 @@ This needs a **dynamic partial**, and the partial must be invoked using the **bl
 
 The inline form (`{{> (concat "icons/" type)}}`) looks tempting, but it throws a page error if the named partial doesn't exist — for example, when a new platform ships before a theme adds the matching icon. gscan rejects the inline form on purpose for this reason. The block form falls back to the inner content instead, so the page keeps rendering.
 
-The `{{/undefined}}` close tag is currently the only form Handlebars accepts for closing a dynamic partial block — see [the discussion on the forum](https://forum.ghost.org/t/social-accounts-v6-38-0-helper-for-theme-social-rendering/62854) for the parser quirk behind it.
+Note the closing tag must be `{{/undefined}}`. This looks unusual, but it's the only form Handlebars accepts when closing a dynamic partial block.
 
 ## Supported platforms
 

--- a/themes/helpers/data/social_accounts.mdx
+++ b/themes/helpers/data/social_accounts.mdx
@@ -1,0 +1,77 @@
+---
+title: "social_accounts"
+description: 'Usage: `{{#social_accounts @site}}{{/social_accounts}}`'
+---
+
+***
+
+`{{#social_accounts}}` is a block helper that iterates over the connected social accounts on a given source object — usually `@site` or an author. The source must be passed as a positional argument.
+
+### Simple Example
+
+Render a row of icons for the social accounts configured under Settings > General > Social accounts:
+
+```handlebars
+{{#social_accounts @site}}
+<a href="{{href}}" target="_blank" rel="noopener" aria-label="{{name}}">
+  {{> (concat "icons/" type)}}
+</a>
+{{/social_accounts}}
+```
+
+## Data Variables
+
+When inside a `{{#social_accounts}}` block, the following properties are available for each account:
+
+* **type** (string) - the storage key (e.g. `twitter`, `bluesky`)
+* **href** (string) - the full URL to the profile
+* **username** (string) - the raw stored handle or URL fragment
+* **name** (string) - the human-readable platform label (e.g. `X`, `Facebook`)
+
+The standard iteration variables are also available:
+
+* **@index** (number) - the 0-based index of the current iteration
+* **@number** (number) - the 1-based index of the current iteration
+* **@first** (boolean) - true if this is the first iteration
+* **@last** (boolean) - true if this is the last iteration
+* **@odd** (boolean) - true if the @index is odd
+* **@even** (boolean) - true if the @index is even
+
+## Usage
+
+### Per-author accounts
+
+When used inside `{{#foreach authors}}`, pass `this` to iterate the current author’s accounts:
+
+```handlebars
+{{#foreach authors}}
+<h3>{{name}}</h3>
+{{#social_accounts this}}
+  <a href="{{href}}" aria-label="{{name}}">{{> (concat "icons/" type)}}</a>
+{{/social_accounts}}
+{{/foreach}}
+```
+
+On an author page, the author is named `author`:
+
+```handlebars
+{{#social_accounts author}}
+<a href="{{href}}" aria-label="{{name}}">{{> (concat "icons/" type)}}</a>
+{{/social_accounts}}
+```
+
+### \{\{else}} and negation
+
+Like all block helpers, `{{#social_accounts}}` supports an `{{else}}` block, which is executed when there are no connected accounts:
+
+```handlebars
+{{#social_accounts @site}}
+<a href="{{href}}">{{name}}</a>
+{{else}}
+<p>No social accounts connected yet.</p>
+{{/social_accounts}}
+```
+
+## Supported platforms
+
+`twitter`, `facebook`, `linkedin`, `bluesky`, `threads`, `mastodon`, `tiktok`, `youtube`, `instagram`. Platforms without a value set on the source are skipped.

--- a/themes/helpers/data/social_accounts.mdx
+++ b/themes/helpers/data/social_accounts.mdx
@@ -23,7 +23,7 @@ Render a row of icons for the social accounts configured under Settings > Genera
 
 When inside a `{{#social_accounts}}` block, the following properties are available for each account:
 
-* **type** (string) - the storage key (e.g. `twitter`, `bluesky`)
+* **type** (string) - the platform key (e.g. `x`, `bluesky`)
 * **href** (string) - the full URL to the profile
 * **username** (string) - the raw stored handle or URL fragment
 * **name** (string) - the human-readable platform label (e.g. `X`, `Facebook`)
@@ -74,4 +74,4 @@ Like all block helpers, `{{#social_accounts}}` supports an `{{else}}` block, whi
 
 ## Supported platforms
 
-`twitter`, `facebook`, `linkedin`, `bluesky`, `threads`, `mastodon`, `tiktok`, `youtube`, `instagram`. Platforms without a value set on the source are skipped.
+`x`, `facebook`, `linkedin`, `bluesky`, `threads`, `mastodon`, `tiktok`, `youtube`, `instagram`. Platforms without a value set on the source are skipped.

--- a/themes/helpers/data/social_accounts.mdx
+++ b/themes/helpers/data/social_accounts.mdx
@@ -14,10 +14,15 @@ Render a row of icons for the social accounts configured under Settings > Genera
 ```handlebars
 {{#social_accounts @site}}
 <a href="{{href}}" target="_blank" rel="noopener" aria-label="{{name}}">
-  {{> (concat "icons/" type)}}
+  {{#> (concat "icons/" type)}}
+    {{!-- Fallback rendered if the per-platform partial is missing --}}
+    <span class="icon icon-{{type}}">{{name}}</span>
+  {{/undefined}}
 </a>
 {{/social_accounts}}
 ```
+
+The examples use the **block dynamic partial form** (`{{#> (concat …)}}…{{/undefined}}`) rather than the inline `{{> (concat …)}}` form. The block form renders the fallback content if the named partial doesn't exist — for example, if a new social platform ships before the theme adds a matching icon. The inline form throws a page error in that case.
 
 ## Data Variables
 
@@ -47,7 +52,11 @@ When used inside `{{#foreach authors}}`, pass `this` to iterate the current auth
 {{#foreach authors}}
 <h3>{{name}}</h3>
 {{#social_accounts this}}
-  <a href="{{href}}" aria-label="{{name}}">{{> (concat "icons/" type)}}</a>
+  <a href="{{href}}" aria-label="{{name}}">
+    {{#> (concat "icons/" type)}}
+      <span class="icon icon-{{type}}">{{name}}</span>
+    {{/undefined}}
+  </a>
 {{/social_accounts}}
 {{/foreach}}
 ```
@@ -56,7 +65,11 @@ On an author page, the author is named `author`:
 
 ```handlebars
 {{#social_accounts author}}
-<a href="{{href}}" aria-label="{{name}}">{{> (concat "icons/" type)}}</a>
+<a href="{{href}}" aria-label="{{name}}">
+  {{#> (concat "icons/" type)}}
+    <span class="icon icon-{{type}}">{{name}}</span>
+  {{/undefined}}
+</a>
 {{/social_accounts}}
 ```
 

--- a/themes/helpers/data/social_accounts.mdx
+++ b/themes/helpers/data/social_accounts.mdx
@@ -9,20 +9,15 @@ description: 'Usage: `{{#social_accounts @site}}{{/social_accounts}}`'
 
 ### Simple Example
 
-Render a row of icons for the social accounts configured under Settings > General > Social accounts:
+Render a row of links for the social accounts configured under Settings > General > Social accounts:
 
 ```handlebars
 {{#social_accounts @site}}
 <a href="{{href}}" target="_blank" rel="noopener" aria-label="{{name}}">
-  {{#> (concat "icons/" type)}}
-    {{!-- Fallback rendered if the per-platform partial is missing --}}
-    <span class="icon icon-{{type}}">{{name}}</span>
-  {{/undefined}}
+  <span class="icon icon-{{type}}">{{name}}</span>
 </a>
 {{/social_accounts}}
 ```
-
-The examples use the **block dynamic partial form** (`{{#> (concat …)}}…{{/undefined}}`) rather than the inline `{{> (concat …)}}` form. The block form renders the fallback content if the named partial doesn't exist — for example, if a new social platform ships before the theme adds a matching icon. The inline form throws a page error in that case.
 
 ## Data Variables
 
@@ -53,9 +48,7 @@ When used inside `{{#foreach authors}}`, pass `this` to iterate the current auth
 <h3>{{name}}</h3>
 {{#social_accounts this}}
   <a href="{{href}}" aria-label="{{name}}">
-    {{#> (concat "icons/" type)}}
-      <span class="icon icon-{{type}}">{{name}}</span>
-    {{/undefined}}
+    <span class="icon icon-{{type}}">{{name}}</span>
   </a>
 {{/social_accounts}}
 {{/foreach}}
@@ -66,9 +59,7 @@ On an author page, the author is named `author`:
 ```handlebars
 {{#social_accounts author}}
 <a href="{{href}}" aria-label="{{name}}">
-  {{#> (concat "icons/" type)}}
-    <span class="icon icon-{{type}}">{{name}}</span>
-  {{/undefined}}
+  <span class="icon icon-{{type}}">{{name}}</span>
 </a>
 {{/social_accounts}}
 ```
@@ -84,6 +75,27 @@ Like all block helpers, `{{#social_accounts}}` supports an `{{else}}` block, whi
 <p>No social accounts connected yet.</p>
 {{/social_accounts}}
 ```
+
+### Using partials
+
+Most themes ship a separate icon partial per platform — `partials/icons/x.hbs`, `partials/icons/facebook.hbs`, and so on — and want `{{#social_accounts}}` to pull in the right one based on `{{type}}`.
+
+This needs a **dynamic partial**, and the partial must be invoked using the **block form** (`{{#> …}}…{{/undefined}}`):
+
+```handlebars
+{{#social_accounts @site}}
+<a href="{{href}}" target="_blank" rel="noopener" aria-label="{{name}}">
+  {{#> (concat "icons/" type)}}
+    {{!-- Fallback rendered when no per-platform icon partial exists --}}
+    <span class="icon icon-web">{{name}}</span>
+  {{/undefined}}
+</a>
+{{/social_accounts}}
+```
+
+The inline form (`{{> (concat "icons/" type)}}`) looks tempting, but it throws a page error if the named partial doesn't exist — for example, when a new platform ships before a theme adds the matching icon. gscan rejects the inline form on purpose for this reason. The block form falls back to the inner content instead, so the page keeps rendering.
+
+The `{{/undefined}}` close tag is currently the only form Handlebars accepts for closing a dynamic partial block — see [the discussion on the forum](https://forum.ghost.org/t/social-accounts-v6-38-0-helper-for-theme-social-rendering/62854) for the parser quirk behind it.
 
 ## Supported platforms
 

--- a/themes/helpers/data/social_url.mdx
+++ b/themes/helpers/data/social_url.mdx
@@ -12,6 +12,8 @@ When called inside an author scope (e.g. `{{#author}}` or `{{#foreach authors}}`
 
 Supported platforms: `facebook`, `twitter`, `linkedin`, `threads`, `bluesky`, `mastodon`, `tiktok`, `youtube`, `instagram`. All nine are configurable both per-author (Staff > [user]) and sitewide (Settings > General > Social accounts).
 
+To render a row of icons for every connected platform on a single object, see [`{{#social_accounts}}`](/themes/helpers/data/social_accounts/).
+
 ### Examples
 
 Output the author’s Threads URL, using an `author` block:


### PR DESCRIPTION
## Summary

Documents the new `{{#social_accounts}}` block helper (added in TryGhost/Ghost#27834, shipped in 6.38; followed by TryGhost/Ghost#27871 in 6.39 which renamed the X/Twitter `type` from `twitter` to `x`).

The helper iterates the connected social accounts on a given source object — typically `@site` or an author — replacing ~27 lines of repetitive `{{#if twitter}}…{{#if facebook}}…` blocks with a single iterator, while keeping themes in full control of markup, classes, and icon partials.

```handlebars
{{#social_accounts @site}}
<a href="{{href}}" target="_blank" rel="noopener" aria-label="{{name}}">
  <span class="icon icon-{{type}}">{{name}}</span>
</a>
{{/social_accounts}}
```

## Structure of the new page

- **Simple Example** — uses a plain `<span class="icon icon-{{type}}">` so readers see the helper iterate before any partial-related complexity.
- **Data Variables** — `type`, `href`, `username`, `name`, plus the standard `@first`/`@last`/`@index`/etc.
- **Usage** — three small subsections covering the per-author case (`{{#social_accounts this}}` inside `{{#foreach authors}}`), the author page (`{{#social_accounts author}}`), and the `{{else}}` block for empty state.
- **Usage > Using partials** — introduces the dynamic-partial pattern as an advanced case. Documents the block form (`{{#> (concat …)}}…{{/undefined}}`) and explains *why*: the inline form throws a page error when the named partial is missing, and gscan rejects it on purpose for that reason. Links to the [forum thread](https://forum.ghost.org/t/social-accounts-v6-38-0-helper-for-theme-social-rendering/62854) for the `{{/undefined}}` close-tag parser quirk.
- **Supported platforms** — the canonical list (`x`, `facebook`, `linkedin`, `bluesky`, `threads`, `mastodon`, `tiktok`, `youtube`, `instagram`).

## Other changes

- **`themes/helpers/data.mdx`** — Adds a row for `social_accounts` to the data helpers index table, immediately above `social_url`.
- **`docs.json`** — Adds the new page to the Data helpers nav, alphabetised next to `social_url`.
- **`themes/helpers/data/social_url.mdx`** — Adds a one-line cross-link pointing readers at `{{#social_accounts}}` for the "render all connected platforms at once" use case. (Held back from #61 to avoid an in-flight conflict; included here now that #61 has merged.)

## Companion / related

- TryGhost/Ghost#27834 — the helper PR (merged & shipped in 6.38)
- TryGhost/Ghost#27871 — `type: "twitter"` → `type: "x"` fix (merged & shipping in 6.39)
- TryGhost/gscan#802 — adds `social_accounts` to gscan's `knownHelpers`
- #61 — `{{social_url}}` fallback documentation fix (merged)
