### PR TITLE
Modernize @page helper docs

### DIFF
--- a/themes/helpers/data/page.mdx
+++ b/themes/helpers/data/page.mdx
@@ -5,11 +5,9 @@ description: The `@page` object provides access to page properties, which are av
 
 ***
 
-* `@page.show_title_and_feature_image` - boolean toggle set on the page settings panel in the editor. Defaults to `true`.
+* `@page.show_title_and_feature_image` - `true` (default) or `false` boolean toggle set on the page settings panel in the editor. 
 
 This toggle lets editors hide a page’s title and feature image on a per-page basis, useful for pages that look radically different from posts (full-width headers, CTAs, landing pages). Gate any relevant markup in your page templates for the toggle to take effect.
-
-The `@page` object requires Ghost 5.54.1 or later.
 
 ## Example code
 
@@ -27,4 +25,4 @@ The `@page` object requires Ghost 5.54.1 or later.
 
 As a reminder, cards that have the ability to be set to full width are header cards, signup cards, image cards, and video cards. When an image or video has a caption, it will have the class `.kg-card-hascaption`, and maintaining spacing is desirable in this case.
 
-The implementation of these changes will look different on every theme. Find examples of these recommended changes in Casper [here](https://github.com/TryGhost/Casper/commit/d9c9390e17c1df1322ebfec774886058a56a0891) (1 and 3) and [here](https://github.com/TryGhost/Casper/blob/a60e3e976a341df462ba948d395bc52c37faffa4/assets/css/screen.css#L1345-L1348) (2).
+The implementation of these changes will look different on every theme. Find examples of these recommended changes in Source [here](https://github.com/TryGhost/Source/blob/main/page.hbs#L9) (1 and 3) and [here](https://github.com/TryGhost/Casper/blob/a60e3e976a341df462ba948d395bc52c37faffa4/assets/css/screen.css#L1345-L1348) (2).

--- a/themes/helpers/data/page.mdx
+++ b/themes/helpers/data/page.mdx
@@ -7,7 +7,7 @@ description: The `@page` object provides access to page properties, which are av
 
 * `@page.show_title_and_feature_image` - boolean toggle set on the page settings panel in the editor. Defaults to `true`.
 
-This toggle lets editors hide a page’s title and feature image to create pages that look radically different than posts (for example, full-width headers, CTAs, and landing pages). Themes need to gate the title and feature image markup with `{{#if @page.show_title_and_feature_image}}` for the setting to take effect.
+This toggle lets editors hide a page’s title and feature image on a per-page basis — useful for pages that look radically different from posts (full-width headers, CTAs, landing pages). Gate any relevant markup in your page templates with `{{#if @page.show_title_and_feature_image}}` for the toggle to take effect.
 
 The `@page` object requires Ghost 5.54.1 or later.
 

--- a/themes/helpers/data/page.mdx
+++ b/themes/helpers/data/page.mdx
@@ -7,16 +7,16 @@ description: The `@page` object provides access to page properties, which are av
 
 * `@page.show_title_and_feature_image` - boolean toggle set on the page settings panel in the editor. Defaults to `true`.
 
-This toggle lets editors hide a page’s title and feature image on a per-page basis — useful for pages that look radically different from posts (full-width headers, CTAs, landing pages). Gate any relevant markup in your page templates with `{{#if @page.show_title_and_feature_image}}` for the toggle to take effect.
+This toggle lets editors hide a page’s title and feature image on a per-page basis, useful for pages that look radically different from posts (full-width headers, CTAs, landing pages). Gate any relevant markup in your page templates for the toggle to take effect.
 
 The `@page` object requires Ghost 5.54.1 or later.
 
 ## Example code
 
 ```handlebars
-{{#if @page.show_title_and_feature_image}}
+{{#match @page.show_title_and_feature_image}}
 ...content...
-{{/if}}
+{{/match}}
 ```
 
 ## Styling tips when hiding the title and feature image

--- a/themes/helpers/data/page.mdx
+++ b/themes/helpers/data/page.mdx
@@ -5,20 +5,18 @@ description: The `@page` object provides access to page properties, which are av
 
 ***
 
-* `@page.show_title_and_feature_image` - true (default) or false value from Ghost Editor
+* `@page.show_title_and_feature_image` - boolean toggle set on the page settings panel in the editor. Defaults to `true`.
 
-This toggle, only available for pages, lets users hide a page’s title and feature image to create pages that look radically different than posts (for example, full-width headers, CTAs, and landing pages).
+This toggle lets editors hide a page’s title and feature image to create pages that look radically different than posts (for example, full-width headers, CTAs, and landing pages). Themes need to gate the title and feature image markup with `{{#if @page.show_title_and_feature_image}}` for the setting to take effect.
 
-This setting is only available when using the [new Beta editor](https://ghost.org/changelog/editor-beta/). However, since the `@page.show_title_and_feature_image` is always present and defaults to `true`, supporting this feature in your theme won’t break anything for anyone using the old editor.
-
-Using the `@page` object is **not backward-compatible** with earlier versions of Ghost: once implemented the theme will only be compatible with Ghost 5.54.1 or later.
+The `@page` object requires Ghost 5.54.1 or later.
 
 ## Example code
 
 ```handlebars
-{{#match @page.show_title_and_feature_image}}
+{{#if @page.show_title_and_feature_image}}
 ...content...
-{{/match}}
+{{/if}}
 ```
 
 ## Styling tips when hiding the title and feature image


### PR DESCRIPTION
## Summary

The `@page` helper docs page still framed the per-page `show_title_and_feature_image` toggle in terms of the "new Beta editor" — long obsolete framing — and the example code used `{{#match}}` for what is naturally an `{{#if}}` check.

Paired with TryGhost/gscan#813 (which rewrites the corresponding GS110 error to drop the same "Beta editor" wording and recommend `{{#if}}`), so the docs page and the gscan error now point at the same pattern.

## Changes

- Drop the "new Beta editor" paragraph and the "won't break anything for anyone using the old editor" comparison.
- Collapse the compat note to a single line: "The `@page` object requires Ghost 5.54.1 or later."
- Rephrase the property description from "true (default) or false value from Ghost Editor" to plain "boolean toggle set on the page settings panel in the editor. Defaults to `true`."
- Add a sentence pointing at the recommended `{{#if @page.show_title_and_feature_image}}` gating pattern.
- Change the example code from `{{#match}}` to `{{#if}}` to match.