### PR TITLE
Document dynamic partials and the block-form requirement

### DIFF
--- a/themes/helpers/utility/partials.mdx
+++ b/themes/helpers/utility/partials.mdx
@@ -51,3 +51,18 @@ Partials can take properties as well which provide the option to set contextual 
   </form>
 </aside>
 ```
+
+### Dynamic partials
+
+You can pick a partial name dynamically with a sub-expression rather than a string literal. This is useful when iterating over a collection where each item needs a different partial, for example rendering per-platform social icons.
+
+Use the **block form** for dynamic partials, not the inline form. The block form falls back to its inner content when the named partial doesn’t exist; the inline form throws a page error and breaks the rendered page.
+
+```handlebars
+{{#> (concat "icons/" type)}}
+  {{!-- Fallback rendered when no matching partial exists --}}
+  <span class="icon icon-default">{{name}}</span>
+{{/undefined}}
+```
+
+Note the closing tag must be `{{/undefined}}`. This looks unusual, but it’s the only form Handlebars accepts when closing a dynamic partial block.


### PR DESCRIPTION
## Summary

The `{{> "partial"}}` helper docs only covered static partials. Theme authors who used a sub-expression as the partial name (`{{> (concat "icons/" type)}}`) had no docs reference for the right pattern. The gscan rule for that case (`GS005-NO-INLINE-DYNAMIC-PARTIAL`, see TryGhost/gscan#815) now links here for the full explanation.

## Change

`themes/helpers/utility/partials.mdx` — adds a "Dynamic partials" section that covers:
- When you'd use a dynamic partial name (iterating a collection where each item needs a different partial)
- Why the block form is required (inline form throws when the named partial doesn't exist)
- The `{{/undefined}}` closing-tag parser quirk

Same content shape as the "Using partials" section on the `{{#social_accounts}}` page (TryGhost/Docs#62), so theme authors landing here from either the social-accounts helper or the gscan dialog see consistent guidance.