### PR TITLE
Update Assets Handlebars example to use proper formatting

### DIFF
--- a/themes/helpers/utility/asset.mdx
+++ b/themes/helpers/utility/asset.mdx
@@ -22,14 +22,14 @@ For example:
 
 ```handlebars
 <!-- Styles -->
-<link rel="stylesheet" type="text/css" href="{{asset 'css/style.css'}}" />
+<link rel="stylesheet" type="text/css" href="{{asset "css/style.css"}}" />
 
 <!-- Serving a minified asset in production and unminified file in development using hasMinFile -->
-<link rel="stylesheet" type="text/css" href="{{asset 'css/style.css' hasMinFile='true'}}" />
+<link rel="stylesheet" type="text/css" href="{{asset "css/style.css" hasMinFile='true'}}" />
 
 <!-- Scripts -->
-<script type="text/javascript" src="{{asset 'js/index.js'}}"></script>
+<script type="text/javascript" src="{{asset "js/index.js"}}"></script>
 
 <!-- Images -->
-<img src="{{asset 'images/my-image.jpg'}}" />
+<img src="{{asset "images/my-image.jpg"}}" />
 ```

--- a/themes/helpers/utility/asset.mdx
+++ b/themes/helpers/utility/asset.mdx
@@ -25,7 +25,7 @@ For example:
 <link rel="stylesheet" type="text/css" href="{{asset "css/style.css"}}" />
 
 <!-- Serving a minified asset in production and unminified file in development using hasMinFile -->
-<link rel="stylesheet" type="text/css" href="{{asset "css/style.css" hasMinFile='true'}}" />
+<link rel="stylesheet" type="text/css" href="{{asset "css/style.css" hasMinFile="true"}}" />
 
 <!-- Scripts -->
 <script type="text/javascript" src="{{asset "js/index.js"}}"></script>


### PR DESCRIPTION
Assets handlebar syntax requires double-quotes. The current, live version shows single quotes around the path names. This confuses devs who may not be as familiar with the Handlebars syntax.