### PR TITLE
Update Node compatibility docs

### DIFF
--- a/faq/node-versions.mdx
+++ b/faq/node-versions.mdx
@@ -7,9 +7,6 @@ description: Ghost’s current required Node version is Node v22 LTS.
 
 | Version                      | Support Level   |
 | ---------------------------- | --------------- |
-| 17.x and below               | Unsupported     |
-| 18.x (Node v18 Hydrogen LTS) | Unsupported     |
-| 19.x                         | Unsupported     |
 | 20.x (Node v20 Iron LTS)     | Unsupported     |
 | 21.x                         | Unsupported     |
 | **22.x (Node v22 Jod LTS)**  | **Required**    |
@@ -71,7 +68,7 @@ If you want to run Ghost on the latest version of Node, you can, however, we can
 
 ## Node compatibility matrix
 
-| Released   | Version  | Node support                         | Notes                                                                                          |
+| Released   | Ghost    | Node.js                              | Notes                                                                                          |
 | ---------- | -------- | ------------------------------------ | ---------------------------------------------------------------------------------------------- |
 | 2017/12/05 | ≥1.18.3  | ^4.5.0, ^6.9.0 or ^8.9.0             |                                                                                                |
 | 2018/04/17 | ≥1.22.3  |                                      | Bumped Ghost-CLI to ^1.7.0, which requires ^4.5.0, ^6.9.0 or ^8.9.0                            |
@@ -99,4 +96,5 @@ If you want to run Ghost on the latest version of Node, you can, however, we can
 | 2023/10/27 | ≥5.71.0  | ^18.12.1                             | Removed Node 16                                                                                |
 | 2024/04/19 | ≥5.82.3  | ^18.12.1 \|\| ^20.11.1               | Added Node 20                                                                                  |
 | 2025/02/21 | ≥5.110.0 | ^18.12.1 \|\| ^20.11.1 \|\| ^22.13.1 | Added Node 22 and bumped Ghost-CLI to ^1.27.0                                                  |
+| 2025/06/18 | ≥5.126.0 | ^18.18.0 \|\| ^20.11.1 \|\| ^22.13.1 | Bumped Node 18 minimum                                                                         |
 | 2025/08/04 | ≥6.0.0   | ^22.13.1                             | Removed Node 18 and Node 20  |


### PR DESCRIPTION
## Summary
- remove obsolete Node 17, 18, and 19 rows from the current support table
- add the Ghost 5.126.0 compatibility row with the Node 18.18.0 minimum
- rename the compatibility matrix headers from `Version` to `Ghost` and `Node support` to `Node.js`

## Why
Yarn validates the Mocha 11 engine requirement from the Ghost 5.126.0+ lockfile during install, so Node 18.12.1 fails even though the older matrix row said it was supported.

Closes #56

## Validation
- git diff --check
- validated MDX table pipe counts with a local Node script

Note: mintlify broken-links was not run because the Mintlify CLI is not installed in this environment.