### PR TITLE
Document generated excerpt limit

### DIFF
--- a/themes/helpers/data/excerpt.mdx
+++ b/themes/helpers/data/excerpt.mdx
@@ -10,8 +10,12 @@ description: 'Usage: `{{excerpt}}`'
 
 If the post’s `custom_excerpt` property is set, then the helper will always output the `custom_excerpt` content ignoring the `words` & `characters` attributes.
 
-When both `html` and `custom_excerpt` properties are not set (for example, when member content gating strips the `html`) the output is generated from post’s `excerpt` property.
+When both `html` and `custom_excerpt` properties are not set (for example, when member content gating strips the `html`) the output is generated from the post’s `excerpt` property.
+
+The `excerpt` property is limited to the first 500 characters of the post’s plaintext output. To output a longer preview from the post body, use the [`{{content}}`](/themes/helpers/data/content/) helper instead.
 
 You can limit the amount of text to output by passing one of the options:
+
+`{{excerpt words="50"}}` will output 50 words of text, up to the generated excerpt length.
 
 `{{excerpt characters="140"}}` will output 140 characters of text (rounding to the end of the current word).


### PR DESCRIPTION
## Summary

- Clarifies that the generated `excerpt` value is limited to the first 500 characters of plaintext output.
- Adds a `words` example that notes the generated excerpt length still applies.
- Points theme developers to `{{content}}` when they need a longer preview from the post body.

## Why

The `{{excerpt}}` helper applies `words` and `characters` options to Ghost's generated excerpt value, not the full post body. Documenting that limit explains why large `words` values do not produce full-body previews.

## Validation

- `npx -y mintlify@latest broken-links`

Fixes #48