### PR TITLE
Fix Admin API endpoint links

### DIFF
--- a/admin-api.mdx
+++ b/admin-api.mdx
@@ -443,18 +443,18 @@ curl -b ghost-cookie.txt \
 
 These are the endpoints & methods currently available to integrations. More endpoints are available through user authentication. Each endpoint has a stability index, see [versioning](/faq/api-versioning) for more information.
 
-| Resource                                      | Methods                               | Stability |
-| --------------------------------------------- | ------------------------------------- | --------- |
-| [/posts/](/admin-api/#posts)             | Browse, Read, Edit, Add, Copy, Delete | Stable    |
-| [/pages/](/admin-api/#pages)             | Browse, Read, Edit, Add, Copy, Delete | Stable    |
-| /tags/                                        | Browse, Read, Edit, Add, Delete       | Stable    |
-| [/tiers/](/admin-api/#tiers)             | Browse, Read, Edit, Add               | Stable    |
-| [/newsletters/](/admin-api/#newsletters) | Browse, Read, Edit, Add               | Stable    |
-| [/offers/](/admin-api/#offers)           | Browse, Read, Edit, Add               | Stable    |
-| [/members/](/admin-api/#members)         | Browse, Read, Edit, Add               | Stable    |
-| [/users/](/admin-api/#users)             | Browse, Read                          | Stable    |
-| [/images/](/admin-api/#images)           | Upload                                | Stable    |
-| [/themes/](/admin-api/#themes)[]()       | Upload, Activate                      | Stable    |
-| [/site/](/admin-api/#site)               | Read                                  | Stable    |
-| [/webhooks/](/admin-api/#webhooks)       | Edit, Add, Delete                     | Stable    |
-
+| Resource                                          | Methods                               | Stability |
+| ------------------------------------------------- | ------------------------------------- | --------- |
+| [/posts/](/admin-api/posts/overview)              | Browse, Read, Edit, Add, Copy, Delete | Stable    |
+| [/pages/](/admin-api/pages/overview)              | Browse, Read, Edit, Add, Copy, Delete | Stable    |
+| /tags/                                            | Browse, Read, Edit, Add, Delete       | Stable    |
+| [/tiers/](/admin-api/tiers/overview)              | Browse, Read, Edit, Add               | Stable    |
+| [/newsletters/](/admin-api/newsletters/overview)  | Browse, Read, Edit, Add               | Stable    |
+| [/offers/](/admin-api/offers/overview)            | Browse, Read, Edit, Add               | Stable    |
+| [/members/](/admin-api/members/overview)          | Browse, Read, Edit, Add               | Stable    |
+| [/labels/](/admin-api/labels/overview)            | Browse, Read, Edit, Add, Delete       | Stable    |
+| [/users/](/admin-api/users/overview)              | Browse, Read                          | Stable    |
+| [/images/](/admin-api/images/overview)            | Upload                                | Stable    |
+| [/themes/](/admin-api/themes/overview)            | Upload, Activate                      | Stable    |
+| [/site/](/admin-api/site/overview)                | Read                                  | Stable    |
+| [/webhooks/](/admin-api/webhooks/overview)        | Edit, Add, Delete                     | Stable    |

--- a/admin-api/labels/overview.mdx
+++ b/admin-api/labels/overview.mdx
@@ -1,0 +1,90 @@
+---
+title: Overview
+---
+
+Labels allow publishers to organize members into internal segments. Labels can be applied when creating or updating members, and can also be managed directly with the labels resource.
+
+### The label object
+
+Whenever you fetch, create, or edit a label, the API responds with an array of one or more label objects.
+
+```json
+// GET /admin/labels/?limit=100&page=1
+{
+    "labels": [
+        {
+            "id": "6958473e4c66da000199e33e",
+            "name": "VIP",
+            "slug": "vip",
+            "created_at": "2026-01-02T22:31:26.000Z",
+            "updated_at": "2026-01-02T22:31:26.000Z"
+        },
+        {
+            "id": "6958473e4c66da000199e33f",
+            "name": "Trial",
+            "slug": "trial",
+            "created_at": "2026-01-02T22:31:26.000Z",
+            "updated_at": "2026-01-02T22:31:26.000Z"
+        }
+    ],
+    "meta": {
+        "pagination": {
+            "page": 1,
+            "limit": 100,
+            "pages": 1,
+            "total": 2,
+            "next": null,
+            "prev": null
+        }
+    }
+}
+```
+
+| Key             | Description                                      |
+| --------------- | ------------------------------------------------ |
+| **id**          | Unique identifier for the label                  |
+| **name**        | Human-readable label name                        |
+| **slug**        | URL-safe identifier generated from the label name |
+| **created\_at** | Date and time the label was created              |
+| **updated\_at** | Date and time the label was last updated         |
+| **count**       | Related resource counts, included when requested |
+
+### Parameters
+
+When retrieving labels from the Admin API, it’s possible to use the `include`, `filter`, `fields`, `limit`, `page`, and `order` parameters.
+
+Available **include** values:
+
+* `count.members` - include the number of members assigned to each label
+
+For browse requests, it’s also possible to use `limit`, `page`, and `order` parameters as documented in the [Content API](/content-api/#parameters).
+
+### Creating a label
+
+```json
+// POST /admin/labels/
+{
+    "labels": [
+        {
+            "name": "VIP"
+        }
+    ]
+}
+```
+
+### Updating a label
+
+```json
+// PUT /admin/labels/{id}/
+{
+    "labels": [
+        {
+            "name": "Paid members"
+        }
+    ]
+}
+```
+
+### Deleting a label
+
+Use `DELETE /admin/labels/{id}/` to delete a label.

--- a/changes.mdx
+++ b/changes.mdx
@@ -174,7 +174,7 @@ Requests to the old, versioned URLs are rewritten internally with the relevant `
 - Removed support for serving secure requests when `config.url` is set to `http`
 - Removed support for configuring the server to connect to a socket instead of a port
 - Deleting a user will no longer remove their posts, but assign them to the site owner instead
-- Site-level email design settings have been replaced with design settings on individual newsletters (see [`/newsletters/* endpoints`](/admin-api/#newsletters))
+- Site-level email design settings have been replaced with design settings on individual newsletters (see [`/newsletters/* endpoints`](/admin-api/newsletters/overview))
 
 ## Ghost 4.0
 

--- a/docs.json
+++ b/docs.json
@@ -252,6 +252,12 @@
                     ]
                   },
                   {
+                    "group": "Labels",
+                    "pages": [
+                      "admin-api/labels/overview"
+                    ]
+                  },
+                  {
                     "group": "Users",
                     "pages": [
                       "admin-api/users/overview",
@@ -273,6 +279,12 @@
                     "pages": [
                       "admin-api/themes/overview",
                       "admin-api/themes/uploading-a-theme"
+                    ]
+                  },
+                  {
+                    "group": "Site",
+                    "pages": [
+                      "admin-api/site/overview"
                     ]
                   },
                   {


### PR DESCRIPTION
## Summary

- Update the Admin API endpoint table to link to the dedicated resource overview pages instead of missing same-page anchors.
- Add navigation entries for linked Admin API resources that were missing from `docs.json`.
- Add a Labels overview page so the endpoint table links to a real target.
- Update a stale newsletter endpoint link in the changelog.

## Why

The Admin API page still linked endpoint resources to anchors such as `/admin-api/#members`, but those anchors no longer exist after the docs were split into resource-specific pages. Users clicking those links landed on the wrong page position instead of the relevant endpoint documentation.

Fixes #57

## Validation

- `npx mintlify@latest broken-links`