### PR TITLE
Show updating post request examples

### DIFF
--- a/admin-api/posts/updating-a-post.mdx
+++ b/admin-api/posts/updating-a-post.mdx
@@ -10,7 +10,6 @@ Required fields: `updated_at`
 
 All writable fields of a post can be updated via the edit endpoint. The `updated_at` field is required as it is used to handle collision detection and ensure you’re not overwriting more recent updates. It is recommended to perform a GET request to fetch the latest data before updating a post. Below is a minimal example for updating the title of a post:
 
-<RequestExample>
 ```json
 // PUT admin/posts/5b7ada404f87d200b5b1f9c8/
 {
@@ -22,13 +21,11 @@ All writable fields of a post can be updated via the edit endpoint. The `updated
     ]
 }
 ```
-</RequestExample>
 
 #### Saving a new revision
 
 If you'd like a new revision of a post saved as part of the update, pass `save_revision=true` in the query string.
 
-<RequestExample>
 ```json
 // PUT admin/posts/5b7ada404f87d200b5b1f9c8/?save_revision=true
 {
@@ -40,7 +37,6 @@ If you'd like a new revision of a post saved as part of the update, pass `save_r
     ]
 }
 ```
-</RequestExample>
 
 #### Tags and Authors
 


### PR DESCRIPTION
## Summary
- Remove the RequestExample wrappers from the updating post guide
- Keep both JSON examples inline so the minimal update and save_revision examples appear next to their explanations

## Why
Mintlify renders RequestExample content in the request side panel. On this page, the two separate RequestExample blocks caused only the first example to appear on the published page, hiding the save_revision request body from readers. Inline code blocks fit this page better because the examples are contextual and sequential.

Fixes #40

## Validation
- git diff --check
- npx --yes mintlify@latest broken-links