### PR TITLE
Add Klipy as primary GIF provider and deprecate Tenor

### DIFF
--- a/config.mdx
+++ b/config.mdx
@@ -97,7 +97,8 @@ There are a number of configuration options which are explained in detail in thi
 | `compress`          | Optional      | Disable compression of server responses                                                                                          |
 | `imageOptimization` | Optional      | Configure image manipulation and processing                                                                                      |
 | `opensea`           | Optional      | Increase rate limit for fetching NFT embeds from OpenSea.io                                                                      |
-| `tenor`             | Optional      | Enable integration with Tenor.com for embedding GIFs directly from the editor                                                    |
+| `klipy`             | Optional      | Enable integration with Klipy for embedding GIFs directly from the editor                                                       |
+| `tenor`             | Optional      | **Deprecated** — Tenor GIF integration (Google shuts down the Tenor API on June 30, 2026)                                        |
 | `twitter`           | Optional      | Add support for rich Twitter embeds in newsletters                                                                               |
 | `portal`            | Optional      | Relocate or remove the scripts for Portal                                                                                        |
 | `sodoSearch`        | Optional      | Relocate or remove the scripts for Sodo search                                                                                   |
@@ -837,11 +838,25 @@ You can [request an OpenSea API key](https://docs.opensea.io/reference/api-keys)
 }
 ```
 
+### Klipy
+
+To enable searching for GIFs directly in the editor, provide an API key for [Klipy](https://klipy.com).
+
+You can [request a Klipy API key](https://partner.klipy.com) for free.
+
+```json
+"klipy": {
+    "apiKey": "..."
+}
+```
+
 ### Tenor
 
-To enable searching for GIFs directly in the editor, provide an API key for [Tenor](https://tenor.com).
+<Warning>
+  Google is shutting down the Tenor API on **June 30, 2026**, and new API key registrations have been frozen since January 2026. We recommend configuring [Klipy](#klipy) instead. Existing Tenor keys keep working until the shutdown date, and GIFs already embedded in your published content will continue to display afterwards.
+</Warning>
 
-You can [request a Tenor API key](https://developers.google.com/tenor/guides/quickstart) from Google’s cloud console, for free.
+If you already have a Tenor API key, GIF search remains available until the shutdown date. Provide your key from Google’s cloud console:
 
 ```json
 "tenor": {


### PR DESCRIPTION
## Summary

- Document Klipy as the primary GIF provider for the editor (`klipy.apiKey`), with key signup at partner.klipy.com
- Mark Tenor as deprecated with a warning callout that calls out the June 30, 2026 Tenor API shutdown and the freeze on new registrations since January 2026, recommending Klipy instead
- Keep Tenor setup steps available during the grace period, since Tenor remains the editor fallback until it's removed in a later phase
- Reassure self-hosters that GIFs already embedded in published content keep displaying after the shutdown
- Add a `klipy` row to the config options table and mark the `tenor` row deprecated

## Why

Google is shutting down the Tenor API on 2026-06-30, and new API key registrations have been frozen since January 2026. Self-hosters reading the config docs need a clear, well-timed heads-up that Tenor is going away and an obvious migration path to Klipy. The same edit that warns them also puts Klipy in the primary spot for new self-hosters, so doing both in one pass is the natural shape of the work.

Ghost-side support for the `klipy` config key landed in TryGhost/Ghost#28109.

## Validation

- git diff --check
- npx --yes mintlify@latest broken-links