### PR TITLE
Documented the all-of filter operator

### DIFF
--- a/content-api/filtering.mdx
+++ b/content-api/filtering.mdx
@@ -73,7 +73,8 @@ Can be one of the following
 * `~` - contains
 * `~^` - starts with
 * `~$` - ends with
-* `[` value, value, … `]` - “in” group, can be negated with `-`
+* `[` value, value, … `]` - “in” group (matches **any** of the comma-separated values), can be negated with `-`
+* `[` value + value + … `]` - “all of” group (matches records that have **every** one of the plus-separated values). Only meaningful for fields that can match multiple related values, such as `tag`/`tags` or member `label`. Cannot be negated.
 
 #### Combinations
 


### PR DESCRIPTION
## Problem

The NQL filter syntax reference documents bracket lists only as an "in" (any-of) group, so there's no user-facing documentation for the new "all of" form. Users had no way to discover it — which is the same gap that led people to guess the syntax in the first place.

## Solution

Documents the plus-separated bracket form as an "all of" group in the Content API filtering syntax reference: it matches records that have every value, is only meaningful for fields that can match multiple related values (such as tags or member labels), and cannot be negated. Also clarifies that the existing comma form matches any of the values.

Depends on the operator landing in NQL (TryGhost/NQL#156) and being consumed by Ghost.