### PR TITLE
Update Gatsby and Eleventy headless docs

### DIFF
--- a/jamstack/eleventy.mdx
+++ b/jamstack/eleventy.mdx
@@ -10,210 +10,251 @@ description: Build a completely custom front-end for your Ghost site with the fl
   <img src="/images/0ed9faae-admin-api-eleventy-diagram_hu5ba97386724b594b90daeca2cbf04049_20855_1000x0_resize_q100_h2_box_3.webp" />
 </Frame>
 
-## Eleventy Starter Ghost
+## Eleventy and Ghost
 
-Eleventy is a “zero configuration” static site generator, meaning it works without any initial setup. That said, having some boilerplate code can really fast track the development process. **That’s why we’ve created an [Eleventy Starter for Ghost](https://github.com/TryGhost/eleventy-starter-ghost) on GitHub.**
+Eleventy is a good fit for a lightweight Ghost front-end. Ghost remains the CMS: editors write posts, manage pages, upload images, and handle publishing in Ghost Admin. Eleventy reads that content from the [Content API](/content-api/) when the site builds.
 
-### Prerequisites
+For most Eleventy sites, use the official [JavaScript Content API client](/content-api/javascript/). It is maintained as part of the [TryGhost SDK](https://github.com/TryGhost/SDK) and works in Node.js during Eleventy builds.
 
-A Ghost account is needed in order to source the content, a self hosted version or a [Ghost (Pro) Account](https://ghost.org/pricing/).
+Use the [Admin API](/admin-api/) only for private server-side scripts, such as imports or custom publishing tools. Do not put an Admin API key in client-side JavaScript.
 
-### Getting started
+## Prerequisites
 
-To begin, create a new project by either cloning the [Eleventy Starter Ghost repo](https://github.com/TryGhost/eleventy-starter-ghost) or forking the repo and then cloning the fork with the following CLI command:
+This configuration requires basic knowledge of JavaScript and HTML templates. You will also need:
+
+* A running Ghost site, either self-hosted or on [Ghost(Pro)](https://ghost.org/pricing/)
+* A custom integration in Ghost Admin so you can copy the Content API URL and key
+* An Eleventy project
+
+Create the Content API key from **Settings -> Integrations** in Ghost Admin. For more detail, see [Content API authentication](/content-api/#authentication).
+
+## Start from a new Eleventy site
+
+If you already have an Eleventy site, skip to the Content API setup. Otherwise, create a small project and install Eleventy:
 
 ```bash
-git clone git@github.com:TryGhost/eleventy-starter-ghost.git
+mkdir my-eleventy-site
+cd my-eleventy-site
+npm init -y
+npm install @11ty/eleventy @tryghost/content-api dotenv
 ```
 
-Navigate into the newly created project and use the command `yarn` to install the dependencies. Check out the official documentation on how to install [Yarn](https://yarnpkg.com/en/docs/install#mac-stable).
+Eleventy documents the same project setup in the [official Eleventy docs](https://www.11ty.dev/docs/).
 
-To test everything installed correctly, use the following command to run your project:
+## Install the Ghost Content API client
+
+If you started with an existing Eleventy site, install the Ghost Content API client:
 
 ```bash
-yarn start
+npm install @tryghost/content-api dotenv
 ```
 
-Then navigate to `http://localhost:8080/` in a browser and view the newly created Eleventy static site.
+Add your Ghost credentials to environment variables. A local `.env` file is fine if your deployment platform loads it and you keep it out of source control.
 
-<Frame>
-  <img src="/images/c8f5e69c-11ty-demo-screenshot_hu790d07d965c54347e81f228a6b805163_953696_1426x0_resize_q100_h2_box_3.webp" />
-</Frame>
-
-***
-
-### Customisation
-
-The Eleventy Starter for Ghost is configured to source content from [https://eleventy.ghost.io](https://eleventy.ghost.io). This can be changed in the `.env` file that comes with the starter.
-
-```yaml
-GHOST_API_URL=https://eleventy.ghost.io
-GHOST_CONTENT_API_KEY=5a562eebab8528c44e856a3e0a
-SITE_URL=http://localhost:8080
+```bash
+GHOST_API_URL=https://demo.ghost.io
+GHOST_CONTENT_API_KEY=22444f78447824223cefc48062
+GHOST_API_VERSION=v6.0
 ```
 
-Change the `GHOST_API_URL` value to the URL of the site. For Ghost(Pro) customers, this is the Ghost URL ending in .ghost.io, and for people using the self-hosted version of Ghost, it’s the same URL used to view the admin panel.
+For Ghost(Pro), the URL is usually your `.ghost.io` URL. For self-hosted Ghost, use the public URL for your Ghost install.
 
-Change the `GHOST_CONTENT_API_KEY` value to a key associated with the Ghost site. A key can be provided by creating an integration within the Ghost Admin. Navigate to Integrations and click “Add new integration”. Name the integration, something related like “Eleventy”, click create.
+## Fetch Ghost content with a global data file
 
-<Frame>
-  <img src="/images/d3673af2-apikey_huc23d3a1fbe859434094a9db94f574d9a_265920_2920x0_resize_q100_h2_box_3.webp" />
-</Frame>
-
-More information can be found on the [Content API documentation](/content-api/#key).
-
-**Using [Netlify](https://www.netlify.com/) to host your site? If so, the `netlify.toml` file that comes with the starter template provides the deployment configuration straight out of the box.**
-
-***
-
-## Next steps
-
-[The official Eleventy docs](https://www.11ty.io/docs) is a great place to learn more about how Eleventy works and how it can be used to build static sites.
-
-There’s also a guide for setting up a new static site, such as Eleventy, [with the hosting platform Netlify](https://ghost.org/integrations/netlify/) so Netlify can listen for updates on a Ghost site and rebuild the static site.
-
-For community led support about linking and building a Ghost site with Eleventy, [visit the forum](https://forum.ghost.org/c/themes/).
-
-## Examples
-
-*Here are a few common examples of using the Ghost Content API within an Eleventy project.*\*
-
-Retrieving data from the Content API within an Eleventy project is pretty similar to using the API in a JavaScript application. However there are a couple of conventions and techniques that will make the data easier to access when creating template files. The majority of these examples are intended to be placed in the `.eleventy.js` file in the root of the project, to find out more on configuring Eleventy refer to [their official documentation](https://www.11ty.io/docs/config/).
-
-## Initialising the Content API
-
-More information on setting up and using the Content API using the JavaScript Client Library can be found in [our API documentation](/content-api/javascript/)
+Eleventy global data files make API data available to every template. Create `_data/ghost.js`:
 
 ```js
-const ghostContentAPI = require("@tryghost/content-api");
+// _data/ghost.js
+require("dotenv").config();
+const GhostContentAPI = require("@tryghost/content-api");
 
-const api = new ghostContentAPI({
+const api = new GhostContentAPI({
   url: process.env.GHOST_API_URL,
   key: process.env.GHOST_CONTENT_API_KEY,
-  version: "v6.0"
+  version: process.env.GHOST_API_VERSION || "v6.0",
 });
-```
 
-## Retrieving posts
+async function browseAll(resource, options = {}) {
+  const items = [];
+  let page = 1;
 
-This example retrieves posts from the API and adds them as a new [collection to Eleventy](https://www.11ty.io/docs/collections/). The example also performs some sanitisation and extra meta information to each post:
+  while (page) {
+    const response = await resource.browse({
+      ...options,
+      limit: 100,
+      page,
+    });
 
-* Adding tag and author meta information to each post
-* Converting post date to a [JavaScript date object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) for easier manipulation in templates
-* Bring featured posts to the top of the list
-
-The maximum amount of items that can be fetched from a resource at once is 100, so use pagination to make sure all of the items are fetched:
-```js
-config.addCollection("posts", async function(collection) {
-  try {
-    let page = 1;
-    let hasMore = true;
-
-    while (hasMore) {
-      const posts = await api.posts.browse({
-        include: "tags,authors",
-        limit: 100,
-        page,
-      });
-
-      if (posts && posts.length > 0) {
-        collection.push(...posts.map((post) => ({
-          ...post,
-          url: stripDomain(post.url),
-          primary_author: {
-            ...post.primary_author,
-            url: stripDomain(post.primary_author.url)
-          },
-          tags: post.tags.map(tag => ({
-            ...tag,
-            url: stripDomain(tag.url)
-          })),
-          // Convert publish date into a Date object
-          published_at: new Date(post.published_at)
-        })));
-        // Use the meta pagination info to determine if there are more pages
-        page = posts.meta.pagination.next;
-        hasMore = page !== null;
-      } else {
-        hasMore = false;
-      }
-    }
-
-  // Bring featured post to the top of the list
-  collection.sort((post, nextPost) => nextPost.featured - post.featured);
-  
-  return collection
-  } catch (error) {
-    console.error(error);
-    return [];
+    items.push(...response);
+    page = response.meta.pagination.next || null;
   }
-});
-```
 
-This code fetches **all** posts because Eleventy creates the HTML files when the site is built and needs access to all the content at this step.
+  return items;
+}
 
-## Retrieving posts by tag
-
-You’ll often want a page that shows all the posts that are marked with a particular tag. This example creates an [Eleventy collection](https://www.11ty.io/docs/collections/) for the tags within a Ghost site, as well as attaching all the posts that are related to that tag:
-
-```js
-config.addCollection("tags", async function(collection) {
-  collection = await api.tags
-    .browse({
-      include: "count.posts", // Get the number of posts within a tag
-      limit: 100 // default is 15, max is 100 - use pagination for more
-    })
-    .catch(err => {
-      console.error(err);
-    });
-
-  // Get up to 100 posts with their tags attached
-  const posts = await api.posts
-    .browse({
-      include: "tags,authors",
-      limit: 100 // default is 15, max is 100 - use pagination for more
-    })
-    .catch(err => {
-      console.error(err);
-    });
-
-  // Attach posts to their respective tags
-  collection.map(async tag => {
-    const taggedPosts = posts.filter(post => {
-      return post.primary_tag && post.primary_tag.slug === tag.slug;
-    });
-
-    // Only attach the tagged posts if there are any
-    if (taggedPosts.length) tag.posts = taggedPosts;
-    return tag;
-  });
-
-  return collection;
-});
-```
-
-## Retrieving site settings
-
-We used this example within our [Eleventy Starter](https://github.com/TryGhost/eleventy-starter-ghost), but rather than putting this in the main configuration file it’s better to add it to a [Data file](https://www.11ty.io/docs/data/), which partitions it from other code and allows it to be attached to a global variable like `site`.
-
-```js
 module.exports = async function() {
-  const siteData = await api.settings
-    .browse({
-      include: "icon,url" // Get the site icon and site url
-    })
-    .catch(err => {
-      console.error(err);
-    });
+  const [posts, pages, tags, authors, settings] = await Promise.all([
+    browseAll(api.posts, { include: "tags,authors", order: "published_at DESC" }),
+    browseAll(api.pages, { include: "tags,authors" }),
+    browseAll(api.tags, { include: "count.posts" }),
+    browseAll(api.authors, { include: "count.posts" }),
+    api.settings.browse(),
+  ]);
 
-  return siteData;
+  return {
+    posts,
+    pages,
+    tags,
+    authors,
+    settings,
+  };
 };
 ```
 
-## Asynchronous data retrieval
+Ghost 6.0 and later limit each browse request to 100 records, so static builds need pagination. The helper above follows the `meta.pagination.next` value until there are no more pages. See [pagination for building static sites](/jamstack/#pagination-for-building-static-sites) and [Content API pagination](/content-api/pagination) for the underlying API behavior.
 
-All the examples above use asynchronous functions when getting data from the Content API. This is so Eleventy intentionally awaits until the content has come back completely before it starts building out static files.
+## List posts on the home page
+
+Create `index.njk` and read from the `ghost` data object:
+
+```njk
+---
+title: Latest posts
+---
+
+<!doctype html>
+<html lang="{{ ghost.settings.lang or 'en' }}">
+  <head>
+    <meta charset="utf-8">
+    <title>{{ ghost.settings.title }}</title>
+  </head>
+  <body>
+    <h1>{{ ghost.settings.title }}</h1>
+
+    <ul>
+      {% for post in ghost.posts %}
+        <li>
+          <a href="/posts/{{ post.slug }}/">{{ post.title }}</a>
+          {% if post.primary_author %}
+            by {{ post.primary_author.name }}
+          {% endif %}
+        </li>
+      {% endfor %}
+    </ul>
+  </body>
+</html>
+```
+
+## Create one page per post
+
+Use Eleventy pagination with a page size of `1` to create a static page for every Ghost post.
+
+```njk
+---
+pagination:
+  data: ghost.posts
+  size: 1
+  alias: post
+permalink: "posts/{{ post.slug }}/index.html"
+---
+
+<!doctype html>
+<html lang="{{ ghost.settings.lang or 'en' }}">
+  <head>
+    <meta charset="utf-8">
+    <title>{{ post.title }} - {{ ghost.settings.title }}</title>
+  </head>
+  <body>
+    <article>
+      <h1>{{ post.title }}</h1>
+      {% if post.primary_author %}
+        <p>{{ post.primary_author.name }}</p>
+      {% endif %}
+      {{ post.html | safe }}
+    </article>
+  </body>
+</html>
+```
+
+Ghost returns post HTML from content written in Ghost Admin. Rendering it with the Nunjucks `safe` filter is normal for a trusted CMS source, but do not use it for untrusted user-submitted HTML.
+
+## Create tag and author pages
+
+The same `ghost` data object includes tags and authors. For example, this creates one archive page per tag:
+
+```njk
+---
+pagination:
+  data: ghost.tags
+  size: 1
+  alias: tag
+permalink: "tag/{{ tag.slug }}/index.html"
+---
+
+<!doctype html>
+<html lang="{{ ghost.settings.lang or 'en' }}">
+  <head>
+    <meta charset="utf-8">
+    <title>{{ tag.name }} - {{ ghost.settings.title }}</title>
+  </head>
+  <body>
+    <h1>{{ tag.name }}</h1>
+
+    <ul>
+      {% for post in ghost.posts %}
+        {% if post.primary_tag and post.primary_tag.slug == tag.slug %}
+          <li><a href="/posts/{{ post.slug }}/">{{ post.title }}</a></li>
+        {% endif %}
+      {% endfor %}
+    </ul>
+  </body>
+</html>
+```
+
+For larger sites, pre-group posts by tag in `_data/ghost.js` so templates do less filtering work.
+
+## Run Eleventy locally
+
+Once the data file and templates are in place, start Eleventy's local development server:
+
+```bash
+npx @11ty/eleventy --serve
+```
+
+Eleventy serves the site at `http://localhost:8080/` by default.
+
+## Use the Admin API from private scripts
+
+The Admin API can create, update, and publish content. It is useful for migrations or custom editorial tooling, but it is not needed to render a public Eleventy front-end.
+
+Install the Admin API client only where the key stays private:
+
+```bash
+npm install @tryghost/admin-api
+```
+
+```js
+// scripts/create-draft.js
+const GhostAdminAPI = require("@tryghost/admin-api");
+
+const admin = new GhostAdminAPI({
+  url: process.env.GHOST_API_URL,
+  key: process.env.GHOST_ADMIN_API_KEY,
+  version: "v6.0",
+});
+
+admin.posts.add(
+  {
+    title: "Draft from a private script",
+    html: "<p>This draft was created through the Admin API.</p>",
+    status: "draft",
+  },
+  { source: "html" }
+);
+```
+
+Run Admin API scripts on your own machine, in CI, or on a server. Never ship `GHOST_ADMIN_API_KEY` to the browser.
 
 ## Next steps
 
-Check out our documentation on the [Content API Client Library](/content-api/javascript/) to see what else is possible, many of the examples there overlap with the examples above. [The official Eleventy docs site](https://www.11ty.io/docs)is very extensive as well if you wish to delve deeper into the API.
+Read the [Content API JavaScript client](/content-api/javascript/) docs for available endpoints and options. Eleventy's [global data files](https://www.11ty.dev/docs/data-global/) and [pagination](https://www.11ty.dev/docs/pagination/) docs explain how API data becomes static pages.

--- a/jamstack/gatsby.mdx
+++ b/jamstack/gatsby.mdx
@@ -10,268 +10,275 @@ description: Build a custom front-end for your Ghost site with the power of Gats
   <img src="/images/1f725078-admin-api-gatsby-diagram_hu088f0fec0d83414e79d90f8ae3457e19_21185_1000x0_resize_q100_h2_box_3.webp" />
 </Frame>
 
-## Gatsby Starter Ghost
+## Gatsby and Ghost
 
-One of the best ways to start a new Gatsby site is with a Gatsby Starter, and in this case, it’s no different.
+Gatsby works well with Ghost when Ghost is the CMS and Gatsby is the static front-end. Editors keep writing in Ghost Admin. Gatsby reads published content from the [Content API](/content-api/) at build time, then creates pages from that content.
 
-#### Prerequisites
+For most Gatsby sites, use the official [JavaScript Content API client](/content-api/javascript/). It is maintained as part of the [TryGhost SDK](https://github.com/TryGhost/SDK) and works in Node.js during Gatsby builds.
 
-To use Gatsby Starters, and indeed Gatsby itself, the [Gatsby CLI](https://www.gatsbyjs.com/docs/quick-start/) tool is required. Additionally, a [Ghost account](https://ghost.org/pricing/) is needed to source content and get site related credentials.
+Use the [Admin API](/admin-api/) only in private server-side code, such as an import script or publishing workflow. Do not expose an Admin API key in Gatsby browser code.
 
-#### Getting started
+## Prerequisites
 
-To begin, generate a new project using the [Gatsby Starter Ghost](https://github.com/TryGhost/gatsby-starter-ghost) template with the following CLI command:
+This configuration requires basic knowledge of JavaScript and React. You will also need:
 
-```bash
-gatsby new my-gatsby-site https://github.com/TryGhost/gatsby-starter-ghost.git
-```
+* A running Ghost site, either self-hosted or on [Ghost(Pro)](https://ghost.org/pricing/)
+* A custom integration in Ghost Admin so you can copy the Content API URL and key
+* A Gatsby project
 
-Navigate into the newly created project and use either npm install or yarn to install the dependencies. The Ghost team prefer to use [Yarn](https://yarnpkg.com/en/docs/install#mac-stable).
+Create the Content API key from **Settings -> Integrations** in Ghost Admin. For more detail, see [Content API authentication](/content-api/#authentication).
 
-Before customising and developing in this new Gatsby site, it’s wise to give it a test run to ensure everything is installed correctly. Use the following command to run the project:
+## Start from a new Gatsby site
 
-```bash
-gatsby develop
-```
-
-Then navigate to `http://localhost:8000/` in a browser and view the newly created Gatsby site.
-
-<Frame>
-  <img src="/images/218dae99-gatsby-demo-screenshot_huf503a446e74501027d0049b3b70cf420_364260_1280x0_resize_q100_h2_box_3.webp" />
-</Frame>
-
-## Making it your own
-
-So, you’ve set up a Gatsby site, but it’s not showing the right content. This is where content sourcing comes into play. Gatsby uses [GraphQL](https://graphql.org/) as a method of pulling content from a number of APIs, including Ghost. Sourcing content from Ghost in the Gatsby Starter Ghost template is made possible with the [Gatsby Source Ghost](https://github.com/TryGhost/gatsby-source-ghost) plugin.
-
-Configuring the plugin can be done within the template files. Within the project, navigate to and open the file named `.ghost.json`, which is found at root level:
-
-```json
-// .ghost.json
-{
- "development": {
-  "apiUrl": "https://gatsby.ghost.io",
-  "contentApiKey": "9cc5c67c358edfdd81455149d0"
- },
- "production": {
-  "apiUrl": "https://gatsby.ghost.io",
-  "contentApiKey": "9cc5c67c358edfdd81455149d0"
- }
-}
-```
-
-This json file is set up to make environment variables a bit easier to control and edit. Change the apiUrl value to the URL of the site. For Ghost(Pro) customers, this is the Ghost URL ending in .ghost.io, and for people using the self-hosted version of Ghost, it’s the same URL used to view the admin panel.
-
-In most cases, it’s best to change both the development and production to the same site details. Use the respective environment objects when using production and development content; this is ideal if you’re working with clients and test content. After saving these changes, restart the local server.
-
-Using [Netlify](https://www.netlify.com/) to host your site? If so, the `netlify.toml` file that comes with the starter template provides the deployment configuration straight out of the box.
-
-## Next steps
-
-[The official Gatsby docs](https://www.gatsbyjs.com/docs/gatsby-project-structure/) is a great place to learn more about how typical Gatsby projects are structured and how it can be extended.
-
-Gaining a greater understanding of how data and content can be sourced from the Ghost API with GraphQL will help with extending aforementioned starter project for more specific use cases.
-
-There’s also a guide for setting up a new static site, such as Gatsby, [with the hosting platform Netlify](https://ghost.org/integrations/netlify/).
-
-For community led support about linking and building a Ghost site with Gatsby, [visit the forum](https://forum.ghost.org/c/themes/).
-
-As with all content sources for Gatsby, content is fed in by [GraphQL](https://www.gatsbyjs.com/tutorial/part-four/), and it’s no different with Ghost. The official [Gatsby Source Ghost](https://github.com/TryGhost/gatsby-source-ghost) plugin allows you to pull content from your existing Ghost site.
-
-## Getting started
-
-Installing the plugin is the same as any other Gatsby plugin. Use your CLI tool of choice to navigate to your Gatsby project and a package manager to install it:
+If you already have a Gatsby site, skip to the Content API setup. Otherwise, create a new Gatsby project with the current Gatsby tooling:
 
 ```bash
-# yarn users
-yarn add gatsby-source-ghost
-# npm users
-npm install --save gatsby-source-ghost
+npm init gatsby my-gatsby-site
+cd my-gatsby-site
+npm run develop
 ```
 
-After that, the next step is to get the API URL and Content API Key of the Ghost site. The API URL is domain used to access the Ghost Admin. For Ghost(Pro) customers, this is the `.ghost.io`, for example: `mysite.ghost.io`. For self-hosted versions of Ghost, use the admin panel access URL and ensure that the self-hosted version is served over a https connection. The Content API Key can be found on the Integrations screen of the Ghost Admin.
+Gatsby also documents manual setup in the [official Gatsby docs](https://www.gatsbyjs.com/docs/).
 
-Open the `gatsby-config.js` file and add the following to the `plugins` section:
+## Install the Ghost Content API client
+
+Install the Ghost Content API client in the Gatsby project:
+
+```bash
+npm install @tryghost/content-api dotenv
+```
+
+Add your Ghost credentials to Gatsby environment files. Keep these files out of source control.
+
+```bash
+# .env.development
+GHOST_API_URL=https://demo.ghost.io
+GHOST_CONTENT_API_KEY=22444f78447824223cefc48062
+GHOST_API_VERSION=v6.0
+SITE_URL=http://localhost:8000
+
+# .env.production
+GHOST_API_URL=https://your-site.example.com
+GHOST_CONTENT_API_KEY=your_content_api_key
+GHOST_API_VERSION=v6.0
+SITE_URL=https://www.example.com
+```
+
+For Ghost(Pro), the URL is usually your `.ghost.io` URL. For self-hosted Ghost, use the public URL for your Ghost install.
+
+Gatsby loads `.env.development` and `.env.production`, but Gatsby's Node APIs need `dotenv` to be configured in `gatsby-config.js`:
 
 ```js
 // gatsby-config.js
-{
-  resolve: `gatsby-source-ghost`,
-  options: {
-    apiUrl: `https://<your-site-subdomain>.ghost.io`,
-    contentApiKey: `<your content api key>`
+require("dotenv").config({
+  path: `.env.${process.env.NODE_ENV || "development"}`,
+});
+
+module.exports = {
+  siteMetadata: {
+    siteUrl: process.env.SITE_URL || process.env.GHOST_API_URL,
+  },
+};
+```
+
+## Fetch all posts during the Gatsby build
+
+Gatsby runs `gatsby-node.js` during builds. Use it to fetch Ghost posts and pages, then create static pages from that content.
+
+```js
+// gatsby-node.js
+const path = require("path");
+const GhostContentAPI = require("@tryghost/content-api");
+
+const api = new GhostContentAPI({
+  url: process.env.GHOST_API_URL,
+  key: process.env.GHOST_CONTENT_API_KEY,
+  version: process.env.GHOST_API_VERSION || "v6.0",
+});
+
+async function browseAll(resource, options = {}) {
+  const items = [];
+  let page = 1;
+
+  while (page) {
+    const response = await resource.browse({
+      ...options,
+      limit: 100,
+      page,
+    });
+
+    items.push(...response);
+    page = response.meta.pagination.next || null;
   }
+
+  return items;
+}
+
+function ghostPath(resource) {
+  return new URL(resource.url).pathname;
+}
+
+exports.createPages = async ({ actions, reporter }) => {
+  const { createPage } = actions;
+  const postTemplate = path.resolve("./src/templates/post.js");
+  const pageTemplate = path.resolve("./src/templates/page.js");
+
+  const [posts, pages] = await Promise.all([
+    browseAll(api.posts, {
+      include: "tags,authors",
+      order: "published_at DESC",
+    }),
+    browseAll(api.pages, {
+      include: "tags,authors",
+    }),
+  ]);
+
+  posts.forEach((post) => {
+    createPage({
+      path: ghostPath(post),
+      component: postTemplate,
+      context: { post },
+    });
+  });
+
+  pages.forEach((page) => {
+    createPage({
+      path: ghostPath(page),
+      component: pageTemplate,
+      context: { page },
+    });
+  });
+
+  reporter.info(`Created ${posts.length} Ghost posts and ${pages.length} Ghost pages`);
+};
+```
+
+Ghost 6.0 and later limit each browse request to 100 records, so static builds need pagination. The helper above follows the `meta.pagination.next` value until there are no more pages. See [pagination for building static sites](/jamstack/#pagination-for-building-static-sites) and [Content API pagination](/content-api/pagination) for the underlying API behavior.
+
+## Render a post template
+
+Create a Gatsby template that reads the Ghost post from `pageContext`.
+
+```jsx
+// src/templates/post.js
+import * as React from "react";
+
+export default function GhostPost({ pageContext }) {
+  const { post } = pageContext;
+
+  return (
+    <article>
+      <h1>{post.title}</h1>
+      <p>
+        {post.primary_author?.name}
+        {post.published_at ? ` / ${new Date(post.published_at).toLocaleDateString()}` : null}
+      </p>
+      <div dangerouslySetInnerHTML={{ __html: post.html }} />
+    </article>
+  );
+}
+
+export function Head({ pageContext }) {
+  const { post } = pageContext;
+  const description = post.meta_description || post.excerpt;
+
+  return (
+    <>
+      <title>{post.meta_title || post.title}</title>
+      {description ? <meta name="description" content={description} /> : null}
+      <link rel="canonical" href={post.canonical_url || post.url} />
+    </>
+  );
 }
 ```
 
-Restart the local server to apply these configuration changes.
+Ghost returns post HTML from content written in Ghost Admin. Rendering it with `dangerouslySetInnerHTML` is normal for a trusted CMS source, but do not mix this with untrusted user-submitted HTML.
 
-## Querying Graph with GraphQL
+## Render a page template
 
-The Ghost API provides 5 types of nodes:
+The `gatsby-node.js` example also creates pages, so add a matching page template:
 
-* Post
-* Page
-* Author
-* Tag
-* Settings
+```jsx
+// src/templates/page.js
+import * as React from "react";
 
-These nodes match with the endpoints shown in the [API endpoints documentation](/content-api/#endpoints). Querying these node with GraphQL can be done like so:
+export default function GhostPage({ pageContext }) {
+  const { page } = pageContext;
 
-```gql
-{
-  allGhostPost(sort: { order: DESC, fields: [published_at] }) {
-    edges {
-      node {
-        id
-        slug
-        title
-        html
-        published_at
-      }
-    }
-  }
+  return (
+    <article>
+      <h1>{page.title}</h1>
+      <div dangerouslySetInnerHTML={{ __html: page.html }} />
+    </article>
+  );
+}
+
+export function Head({ pageContext }) {
+  const { page } = pageContext;
+  const description = page.meta_description || page.excerpt;
+
+  return (
+    <>
+      <title>{page.meta_title || page.title}</title>
+      {description ? <meta name="description" content={description} /> : null}
+      <link rel="canonical" href={page.canonical_url || page.url} />
+    </>
+  );
 }
 ```
 
-The above example is retrieving all posts in descending order of the ‘published at’ field. The posts will each come back with an id, slug, title, the content (html) and the ‘published at’ date.
+## Add pages, tags, authors, and settings
+
+The Content API exposes the resources Gatsby usually needs for a headless site:
+
+```js
+const [posts, pages, tags, authors, settings] = await Promise.all([
+  browseAll(api.posts, { include: "tags,authors" }),
+  browseAll(api.pages, { include: "tags,authors" }),
+  browseAll(api.tags, { include: "count.posts" }),
+  browseAll(api.authors, { include: "count.posts" }),
+  api.settings.browse(),
+]);
+```
+
+Use `createPage()` for any resource that needs its own route, such as posts, pages, tag archives, or author archives. Use Gatsby's built-in `Head` API for page metadata, and the official `gatsby-plugin-sitemap` package if you need a generated sitemap.
+
+If you prefer Gatsby's GraphQL data layer, you can use Gatsby's `sourceNodes` API to create nodes from these same Content API responses.
+
+## Use the Admin API from private scripts
+
+The Admin API can create, update, and publish content. It is useful for migrations or custom editorial tooling, but it is not needed to render a public Gatsby front-end.
+
+Install the Admin API client only where the key stays private:
+
+```bash
+npm install @tryghost/admin-api
+```
+
+```js
+// scripts/create-draft.js
+const GhostAdminAPI = require("@tryghost/admin-api");
+
+const admin = new GhostAdminAPI({
+  url: process.env.GHOST_API_URL,
+  key: process.env.GHOST_ADMIN_API_KEY,
+  version: "v6.0",
+});
+
+admin.posts.add(
+  {
+    title: "Draft from a private script",
+    html: "<p>This draft was created through the Admin API.</p>",
+    status: "draft",
+  },
+  { source: "html" }
+);
+```
+
+Run Admin API scripts on your own machine, in CI, or on a server. Never ship `GHOST_ADMIN_API_KEY` to the browser.
 
 ## Next steps
 
-GraphQL is a very powerful tool to query the Ghost API with. This is why we’ve documented a few recipes that will get you started.
+Read the [Content API JavaScript client](/content-api/javascript/) docs for available endpoints and options. Gatsby's [Node API documentation](https://www.gatsbyjs.com/docs/reference/config-files/gatsby-node/) explains how `createPages` and `sourceNodes` fit into the Gatsby build.
 
-To learn more about the plugin itself, check out the [documentation within the repo on GitHub](https://github.com/TryGhost/gatsby-source-ghost#how-to-query). There’s also plenty of documentation on what the Ghost API has to offer when making queries. To learn more about GraphQL as a language, head over to the [official GraphQL docs](https://graphql.org/learn/queries/).
-
-## Use-cases
-
-There are many additional aspects to switching from a typical Ghost front-end to a standalone API driven front-end like Gatsby. The following sections explain some slightly ‘grey area’ topics that have been commonly asked or may be of use when making this transition.
-
-## Switching over
-
-Switching to a new front-end means handling the old front-end in a different way.
-
-One option is to make the old pages canonical, meaning that these pages will remain online, but will reference the new counterparts on the API driven site. Check out the documentation on [using canonical URLs in Ghost](https://ghost.org/help/publishing-options/#add-custom-canonical-urls).
-
-<Frame>
-  <img src="/images/bef9adef-admin-private-option_hub2336ad8c44cf39926a93b72f74de9cd_10436_800x0_resize_q100_h2_box_3.webp" />
-</Frame>
-
-Another way is to turn off the old site entirely and begin directing people to the new site. Ghosts’ front-end can be hidden using the ‘Private Mode’ found in the Ghost Admin under General Settings.
-
-## Generating a sitemap
-
-Providing a well made sitemap for search indexing bots is one of the most important aspects of good SEO. However, creating and maintaining a series of complex ‘for loops’ can be a costly exercise.
-
-<Frame>
-  <img src="/images/14a1eed4-xml-sitemap-before-and-after_huaa7504f9f8a1eda4d36a79fb085bcdc6_679990_2068x0_resize_q100_h2_box_3.webp" />
-</Frame>
-
-The Ghost team have provided an open source plugin for Gatsby to construct an ideal format for generated sitemap XML pages, called [Gatsby Advanced Sitemap plugin](https://github.com/TryGhost/gatsby-plugin-advanced-sitemap). By default, the plugin will generate a single sitemap, but it can be [configured with GraphQL](https://github.com/TryGhost/gatsby-plugin-advanced-sitemap#options) to hook into various data points. Further information can be found in the [sitemap plugin documentation](https://github.com/TryGhost/gatsby-plugin-advanced-sitemap#gatsby-plugin-advanced-sitemap).
-
-The plugin doesn’t just work with Ghost - it’s compatible with an assortment of APIs and content sources. To learn more about using GraphQL and the Ghost API for plugins, such as the Gatsby sitemap plugin, check out our GraphQL Recipes for Ghost.
-
-## Using Gatsby plugins with Ghost content
-
-With the ever expanding list of plugins available for Gatsby, it’s hard to understand which plugins are needed to make a high quality and well functioning site running on the Ghost API.
-
-[Gatsby Source Filesystem](https://www.gatsbyjs.com/plugins/gatsby-source-filesystem/) is a plugin for creating additional directories inside a Gatsby site. This is ideal for storing static files (e.g. error pages), site-wide images, such as logos, and site configuration files like robots.txt.
-
-[Gatsby React Helmet plugin](https://www.gatsbyjs.com/plugins/gatsby-plugin-react-helmet/) is very useful for constructing metadata in the head of any rendered page. The plugin requires minimum configuration, but can be modified to suit the need.
-
-## Further reading
-
-There is plenty of reference material and resources on the [official Gatsby site](https://www.gatsbyjs.com/tutorial/), along with a long list of [available plugins](https://www.gatsbyjs.com/plugins/). It may also be worth understanding the underlying concepts of [static sites](https://jamstack.org/) and how they work differently to other sites.
-
-To get an even more boarder view of performant site development check out web.dev from Google, which explores many topics on creating site for the modern web.
-
-## Examples
-
-Here are a few common examples of using GraphQL to query the Ghost API.
-
-Gatsby uses [GraphQL](https://www.gatsbyjs.com/docs/graphql/) to retrieve content, retrieving content from the Ghost API is no different thanks to the Gatsby Source Ghost plugin. Below are some recipes to retrieve chunks of data from the API that you can use and manipulate for your own needs. More extensive learning can be found in the official [GraphQL documentation](https://graphql.org/graphql-js/passing-arguments/).
-
-## Retrieving posts
-
-This example takes into account a limited amount of posts per page and a ‘skip’ to paginate through those pages of posts:
-
-```gql
-query GhostPostQuery($limit: Int!, $skip: Int!) {
- allGhostPost(
-   sort: { order: DESC, fields: [published_at] },
-   limit: $limit,
-   skip: $skip
- ) {
-  edges {
-   node {
-    ...GhostPostFields
-   }
-  }
- }
-}
-```
-
-## Filtering Posts by tag
-
-Filtering posts by tag is a common pattern, but can be tricky with how the query filter is formulated:
-
-```gql
-{
- allGhostPost(filter: {tags: {elemMatch: {slug: {eq: $slug}}}}) {
-  edges {
-   node {
-    slug
-    ...
-   }
-  }
- }
-}
-```
-
-## Retrieving settings
-
-The Ghost settings node is different to other nodes as it’s a single object - this can be queried like so:
-
-```gql
-{
- allGhostSettings {
-  edges {
-   node {
-    title
-    description
-    lang
-    ...
-    navigation {
-      label
-      url
-    }
-   }
-  }
- }
-}
-```
-
-More information can be found in the [Ghost API documentation](/content-api/#settings).
-
-## Retrieving all tags
-
-Getting all tags from a Ghost site could be used to produce a tag cloud or keyword list:
-
-```gql
-{
- allGhostTag(sort: {order: ASC, fields: name}) {
-   edges {
-     node {
-       slug
-       url
-       postCount
-     }
-   }
- }
-}
-```
-
-## Further reading
-
-Many of the GraphQL queries shown above are used within the [Gatsby Starter Ghost](https://github.com/tryghost/gatsby-starter-ghost) template. With a better understanding of how to use queries, customising the starter will become more straightforward.
-
-Additionally, the [Gatsby Source Ghost plugin](https://github.com/TryGhost/gatsby-source-ghost) allows the use of these queries in any existing Gatsby project you may be working on.
+Gatsby output is static, so new Ghost content appears after the next Gatsby build. Most hosting providers let you trigger a rebuild from a Ghost webhook or build hook.


### PR DESCRIPTION
## Summary

- Replaced Gatsby and Eleventy starter-repo guidance with direct setup flows for modern projects.
- Documented `@tryghost/content-api` usage, Ghost 6 pagination, and framework-native build hooks for Gatsby and Eleventy.
- Added Admin API guidance for private server-side scripts and removed references to archived or deprecated Ghost-maintained starter/plugin paths.

## Validation

- `mint broken-links`
- `git diff --check`
- stale reference scan for archived/deprecated Gatsby and Eleventy repo names
- verified Gatsby setup, Node API, `Head`, and environment variable guidance against Gatsby docs
- verified Eleventy install, global data file, and pagination guidance against Eleventy docs