### PR TITLE
Fixed Dark Grey RGB value in brand color palette

### DIFF
--- a/logos.mdx
+++ b/logos.mdx
@@ -72,7 +72,7 @@ Light backgrounds and tinted greys, accented with Ghost Green.
     <div className='grow'>Dark Grey</div>
     <ul className='not-prose text-sm space-y-1'>
       <li>$darkgrey</li>
-      <li>RGB 21, 33, 42</li>
+      <li>RGB 21, 23, 26</li>
       <li>#15171A</li>
     </ul>
   </div>


### PR DESCRIPTION
The Dark Grey swatch on the [logos page](https://docs.ghost.org/logos) listed `RGB 21, 33, 42`, which doesn't match its hex value `#15171A` (and the swatch's own `bg-[#15171A]` background).

`#15171A` decodes to RGB **21, 23, 26**, so the RGB triplet was the typo. Corrected it to match the hex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)