### PR TITLE
Remove Tenor from GIF configuration docs

### DIFF
--- a/config.mdx
+++ b/config.mdx
@@ -98,7 +98,6 @@ There are a number of configuration options which are explained in detail in thi
 | `imageOptimization` | Optional      | Configure image manipulation and processing                                                                                      |
 | `opensea`           | Optional      | Increase rate limit for fetching NFT embeds from OpenSea.io                                                                      |
 | `klipy`             | Optional      | Enable integration with Klipy for embedding GIFs directly from the editor                                                       |
-| `tenor`             | Optional      | **Deprecated** — Tenor GIF integration (Google shuts down the Tenor API on June 30, 2026)                                        |
 | `twitter`           | Optional      | Add support for rich Twitter embeds in newsletters                                                                               |
 | `portal`            | Optional      | Relocate or remove the scripts for Portal                                                                                        |
 | `sodoSearch`        | Optional      | Relocate or remove the scripts for Sodo search                                                                                   |
@@ -845,20 +844,6 @@ You can [request a Klipy API key](https://partner.klipy.com) for free.
 ```json
 "klipy": {
     "apiKey": "..."
-}
-```
-
-### Tenor
-
-<Warning>
-  Google is shutting down the Tenor API on **June 30, 2026**, and new API key registrations have been frozen since January 2026. We recommend configuring [Klipy](#klipy) instead. Existing Tenor keys keep working until the shutdown date, and GIFs already embedded in your published content will continue to display afterwards.
-</Warning>
-
-If you already have a Tenor API key, GIF search remains available until the shutdown date. Provide your key from Google’s cloud console:
-
-```json
-"tenor": {
-    "googleApiKey": "..."
 }
 ```
 


### PR DESCRIPTION
## Summary

- Remove the `### Tenor` section from the config docs entirely — the deprecation `<Warning>`, the grace-period setup instructions, and the `"tenor": { "googleApiKey": "..." }` snippet
- Drop the deprecated `tenor` row from the config options table
- Klipy is now the only documented GIF provider

## Why

This is the follow-up to #72, which added Klipy as the primary GIF provider and kept Tenor's setup steps around for the grace period. Google shut down the Tenor API on 2026-06-30, so those steps now document a defunct service — keeping them only confuses self-hosters and adds support load. With the API dead, there's no remaining grace period to explain, so Tenor comes out cleanly.

This is the docs counterpart to the Koenig and Ghost code removals happening in the same milestone.

## Validation

- git diff --check