### PR TITLE
Fix stale documentation links and anchors

### DIFF
--- a/admin-api.mdx
+++ b/admin-api.mdx
@@ -53,7 +53,7 @@ Requests with JSON payloads require the `Content-Type: application/json` header.
 
 ### Pagination
 
-All browse endpoints are paginated, returning 15 records by default. You can use the [page](#page) and [limit](#limit) parameters to move through the pages of records. The response object contains a `meta.pagination` key with information on the current location within the records:
+All browse endpoints are paginated, returning 15 records by default. You can use the [page](/content-api/parameters/#page) and [limit](/content-api/parameters/#limit) parameters to move through the pages of records. The response object contains a `meta.pagination` key with information on the current location within the records:
 
 ```json
 "meta": {
@@ -415,7 +415,7 @@ The provided session cookie should be provided with every subsequent API request
 * When using XHR you should set the `withCredentials` property of the xhr to `true`
 * When using cURL you can use the `--cookie` and `--cookie-jar` options to store and send cookies from a text file.
 
-**CSRF Protection**
+#### CSRF Protection
 
 Session-based requests must also include either an Origin (preferred) or a Referer header. The value of these headers is checked against the original session creation requests, in order to prevent Cross-Site Request Forgery (CSRF) in a browser environment. In a browser environment, these headers are handled automatically. For server-side or native apps, the Origin header should be sent with an identifying URL as the value.
 

--- a/admin-api/labels/overview.mdx
+++ b/admin-api/labels/overview.mdx
@@ -57,7 +57,7 @@ Available **include** values:
 
 * `count.members` - include the number of members assigned to each label
 
-For browse requests, it’s also possible to use `limit`, `page`, and `order` parameters as documented in the [Content API](/content-api/#parameters).
+For browse requests, it’s also possible to use `limit`, `page`, and `order` parameters as documented in the [Content API](/content-api/parameters/).
 
 ### Creating a label
 

--- a/admin-api/posts/creating-a-post.mdx
+++ b/admin-api/posts/creating-a-post.mdx
@@ -23,7 +23,7 @@ Create draft and published posts with the add posts endpoint. All fields except 
 }
 ```
 
-A post must always have [at least one author](#tags-and-authors), and this will default to the staff user with the owner role when [token authentication](#token-authentication) is used.
+A post must always have [at least one author](#tags-and-authors), and this will default to the staff user with the owner role when [token authentication](/admin-api/#token-authentication) is used.
 
 #### Source HTML
 

--- a/admin-api/posts/overview.mdx
+++ b/admin-api/posts/overview.mdx
@@ -215,6 +215,6 @@ By default, the API expects and returns content in the **Lexical** format only. 
 
 #### Parameters
 
-When retrieving posts from the admin API, it is possible to use the `include`, `formats`, `filter`, `limit`, `page` and `order` parameters as documented for the [Content API](/content-api/#parameters).
+When retrieving posts from the admin API, it is possible to use the `include`, `formats`, `filter`, `limit`, `page` and `order` parameters as documented for the [Content API](/content-api/parameters/).
 
 Some defaults are different between the two APIs, however the behaviour and availability of the parameters remains the same.

--- a/admin-api/tiers/overview.mdx
+++ b/admin-api/tiers/overview.mdx
@@ -80,6 +80,6 @@ Available **filter** values:
 * `visibility:public|none` - for filtering tiers based on their visibility
 * `active:true|false` - for filtering active or archived tiers
 
-For browse requests, it’s also possible to use `limit`, `page`, and `order` parameters as documented in the [Content API](/content-api/#parameters).
+For browse requests, it’s also possible to use `limit`, `page`, and `order` parameters as documented in the [Content API](/content-api/parameters/).
 
 By default, tiers are ordered by ascending monthly price amounts.

--- a/admin-api/webhooks/creating-a-webhook.mdx
+++ b/admin-api/webhooks/creating-a-webhook.mdx
@@ -6,9 +6,9 @@ title: Creating a Webhook
 POST /admin/webhooks/
 ```
 
-Required fields: `event`, `target_url` Conditionally required field: `integration_id` - required if request is done using [user authentication](#user-authentication) Optional fields: `name`, `secret`, `api_version`
+Required fields: `event`, `target_url` Conditionally required field: `integration_id` - required if request is done using [user authentication](/admin-api/#user-authentication) Optional fields: `name`, `secret`, `api_version`
 
-Example to create a webhook using [token authenticated](#token-authentication) request.
+Example to create a webhook using [token authenticated](/admin-api/#token-authentication) request.
 <RequestExample>
 ```json
 // POST /admin/webhooks/
@@ -21,7 +21,7 @@ Example to create a webhook using [token authenticated](#token-authentication) r
 ```
 </RequestExample>
 
-When creating a webhook through [user authenticated](#user-authentication) request, minimal payload would look like following:
+When creating a webhook through [user authenticated](/admin-api/#user-authentication) request, minimal payload would look like following:
 
 ```json
 // POST /admin/webhooks/

--- a/architecture.mdx
+++ b/architecture.mdx
@@ -57,7 +57,7 @@ Whether you want to publish content from your favourite desktop editor, build a 
 
 Ghost’s public Content API is what delivers published content to the world and can be accessed in a read-only manner by any client to render in a website, app or other embedded media.
 
-Access control is managed via an API key, and even the most complex filters are made simple with our [query language](/content-api/filtering/). The Content API is designed to be fully cachable, meaning you can fetch data as often as you like without limitation.
+Access control is managed via an API key, and even the most complex filters are made simple with our [query language](/content-api/filtering/). The Content API is designed to be fully cacheable, meaning you can fetch data as often as you like without limitation.
 
 ### Admin API
 

--- a/architecture.mdx
+++ b/architecture.mdx
@@ -57,7 +57,7 @@ Whether you want to publish content from your favourite desktop editor, build a 
 
 Ghost’s public Content API is what delivers published content to the world and can be accessed in a read-only manner by any client to render in a website, app or other embedded media.
 
-Access control is managed via an API key, and even the most complex filters are made simple with our [query language](/content-api/#filtering). The Content API is designed to be fully cachable, meaning you can fetch data as often as you like without limitation.
+Access control is managed via an API key, and even the most complex filters are made simple with our [query language](/content-api/filtering/). The Content API is designed to be fully cachable, meaning you can fetch data as often as you like without limitation.
 
 ### Admin API
 

--- a/changes.mdx
+++ b/changes.mdx
@@ -89,7 +89,7 @@ Themes can be validated against 5.x in [GScan](https://gscan.ghost.org).
 
 The syntax used to build custom membership flows has changed significantly.
 
-- Tier benefits are now returned as a list of strings. ([docs](/themes/helpers/data/tiers/#fetching-tiers-with-the-get-helper))
+- Tier benefits are now returned as a list of strings. ([docs](/themes/helpers/data/tiers/#fetching-tiers-with-the-%23get-helper))
 - Paid Tiers now have numeric `monthly_price` and `yearly_price` attributes, and a separate `currency` attribute. ([docs](/themes/helpers/data/tiers/))
 - The following legacy product and price helpers used to build custom membership flows have been removed: `@price`, `@products`, `@product` and `@member.product`. See below for examples of the new syntax for building a custom signup form and account page. ([docs](/themes/members/#member-subscriptions))
 

--- a/config.mdx
+++ b/config.mdx
@@ -250,7 +250,7 @@ Once your site is fully set up [create a Mailgun account](https://signup.mailgun
 
 In addition to this information, you’ll need the password, which can be obtained by clicking the **Reset Password** button. Keep these details for future reference.
 
-Mailgun provides options for using their own subdomains for sending emails, as well as custom domains for a [competitive price](/faq/mailgun-newsletters/#did-you-know-mailgun-doesn-t-have-free-accounts-anymore).
+Mailgun provides options for using its own subdomains or custom domains to send email.
 
 #### Add credentials to `config.production.json`
 
@@ -792,7 +792,7 @@ The following configuration keys are available with default `maxAge` values:
 
 * “frontend” - with `"maxAge": 0`, controls responses coming from public Ghost pages (like the homepage)
 * “contentAPI” - with `"maxAge": 0`, controls responses coming from [Content API](/content-api/)
-* “robotstxt” - with `"maxAge": 3600`, controls responses for `robots.txt` [files](/themes/structure/#robotstxt)
+* “robotstxt” - with `"maxAge": 3600`, controls responses for `robots.txt` [files](/themes/structure/#robots-txt)
 * “sitemap” - with `"maxAge": 3600`, controls responses for `sitemap.xml` [files](https://ghost.org/changelog/xml-sitemaps/)
 * “sitemapXSL” - with `"maxAge": 86400`, controls responses for `sitemap.xsl` files
 * “wellKnown” - with `"maxAge": 86400`, controls responses coming from `*/.wellknown/*` endpoints

--- a/content-api/javascript.mdx
+++ b/content-api/javascript.mdx
@@ -44,7 +44,7 @@ The Content API URL and key can be obtained by creating a new `Custom Integratio
 * `key` - hex string copied from the “Integrations” screen in Ghost Admin
 * `version` - should be set to ‘v6.0’
 
-See the documentation on [Content API authentication](/content-api/#authentication) for more explanation.
+See the documentation on [Content API authentication](/content-api/#key) for more explanation.
 
 ## Endpoints
 
@@ -137,7 +137,7 @@ Get the [latest version](https://unpkg.com/@tryghost/content-api) from [unpkg.co
 
 Ghost provides the `filter` parameter to fetch your content with endless possibilities! Especially useful for retrieving posts according to their tags, authors or other properties.
 
-Ghost uses the NQL query language to create filters in a simple yet powerful string format. See the [NQL Syntax Reference](/content-api/#filtering) for full details.
+Ghost uses the NQL query language to create filters in a simple yet powerful string format. See the [NQL Syntax Reference](/content-api/filtering/#syntax-reference) for full details.
 
 Filters are provided to client libraries via the `filter` property of any `browse` method.
 
@@ -188,7 +188,7 @@ A collection of packages for common API usecases
 * Package: `@tryghost/helpers`
 * Builds: CJS, ES, UMD
 
-The shared helpers are designed for performing data formatting tasks, usually when creating custom frontends. These are the underlying tools that power our [handlebars](/themes/) and [gatsby](/jamstack/gatsby/#custom-helpers) helpers.
+The shared helpers are designed for performing data formatting tasks, usually when creating custom frontends. These are the underlying tools that power our [Handlebars](/themes/) and [Gatsby](/jamstack/gatsby/) helpers.
 
 #### Tags
 

--- a/faq/troubleshooting-mysql-database.mdx
+++ b/faq/troubleshooting-mysql-database.mdx
@@ -23,7 +23,7 @@ This may be caused by `ANSI_QUOTES` [sql mode](https://dev.mysql.com/doc/refman/
 
 To fix this issue:
 
-1. Find and open your `my.cnf` file ([see below](#finding-your-mycnf-file))
+1. Find and open your `my.cnf` file ([see below](#finding-your-my-cnf-file))
 2. Remove `ANSI_QUOTES` or `ANSI` from the `sql_mode` line
 
 ### Error `ER_FK_COLUMN_CANNOT_CHANGE`
@@ -32,7 +32,7 @@ This may be caused by missing the `STRICT_TRANS_TABLES` [sql mode](https://dev.m
 
 To fix this issue:
 
-1. Find and open your `my.cnf` file ([see below](#finding-your-mycnf-file))
+1. Find and open your `my.cnf` file ([see below](#finding-your-my-cnf-file))
 2. Add `STRICT_TRANS_TABLES` to the `sql_mode` line
 
 ### Error `ER_TOO_BIG_ROWSIZE`

--- a/ghost-cli.mdx
+++ b/ghost-cli.mdx
@@ -749,4 +749,4 @@ sudo find /var/www/ghost/* -type d -exec chmod 775 {} \;
 sudo find /var/www/ghost/* -type f -exec chmod 664 {} \;
 ```
 
-The cli doesn’t support directory flags such as `setuid` and `setguid`). If your commands keep failing because of file permissions, ensure your directories have no flags!
+The CLI doesn’t support directory flags such as `setuid` and `setgid`. If your commands keep failing because of file permissions, ensure your directories have no flags!

--- a/ghost-cli.mdx
+++ b/ghost-cli.mdx
@@ -258,7 +258,7 @@ When you install Ghost using Ghost-CLI, the local directory will be setup with a
 
 #### How it works
 
-Setup configures your server ready for running Ghost in production. It assumes the [recommended stack](/install/ubuntu/#prerequisites/) and leaves your site in a production-ready state. Setup is broken down into stages:
+Setup configures your server ready for running Ghost in production. It assumes the [recommended stack](/install/ubuntu/#prerequisites) and leaves your site in a production-ready state. Setup is broken down into stages:
 
 * **mysql** - create a specific MySQL user that is used only for talking to Ghost’s database.
 * **nginx** - creates an nginx configuration
@@ -603,7 +603,7 @@ ghost log --dir /path/to/site/
 
 #### Debugging
 
-There may be some output from Ghost that doesn’t appear in the log files, so for debugging purposes you may also want to try the [ghost run](/ghost-cli#ghost-run) command.
+There may be some output from Ghost that doesn’t appear in the log files, so for debugging purposes you may also want to try the [ghost run](/faq/errors-running-ghost-start/) command.
 
 If you have a custom log configuration the `ghost log` command may not work for you. In particular the `ghost log` command requires that file logging is enabled. See the [logging configuration docs](/config/#logging) for more information.
 
@@ -709,7 +709,7 @@ sudo nginx -t
 sudo nginx -s reload
 ```
 
-**Let’s Encrypt**
+#### Let's Encrypt
 
 [Let’s Encrypt](https://letsencrypt.org/) provides SSL certificates that are accepted by browsers free of charge! This is provided by the non-profit Internet Security Research Group (ISRG). The Ghost-CLI will offer you to generate a free SSL certificate as well as renew it every 60 days.
 

--- a/jamstack/eleventy.mdx
+++ b/jamstack/eleventy.mdx
@@ -26,7 +26,7 @@ This configuration requires basic knowledge of JavaScript and HTML templates. Yo
 * A custom integration in Ghost Admin so you can copy the Content API URL and key
 * An Eleventy project
 
-Create the Content API key from **Settings -> Integrations** in Ghost Admin. For more detail, see [Content API authentication](/content-api/#authentication).
+Create the Content API key from **Settings -> Integrations** in Ghost Admin. For more detail, see [Content API authentication](/content-api/javascript/#authentication).
 
 ## Start from a new Eleventy site
 

--- a/jamstack/gatsby.mdx
+++ b/jamstack/gatsby.mdx
@@ -26,7 +26,7 @@ This configuration requires basic knowledge of JavaScript and React. You will al
 * A custom integration in Ghost Admin so you can copy the Content API URL and key
 * A Gatsby project
 
-Create the Content API key from **Settings -> Integrations** in Ghost Admin. For more detail, see [Content API authentication](/content-api/#authentication).
+Create the Content API key from **Settings -> Integrations** in Ghost Admin. For more detail, see [Content API authentication](/content-api/javascript/#authentication).
 
 ## Start from a new Gatsby site
 

--- a/jamstack/gridsome.mdx
+++ b/jamstack/gridsome.mdx
@@ -80,7 +80,7 @@ Next, update the `contentKey` value to a key associated with the Ghost site. A k
   <img src="/images/d3673af2-apikey_huc23d3a1fbe859434094a9db94f574d9a_265920_2920x0_resize_q100_h2_box_3.webp" />
 </Frame>
 
-For more detailed steps on setting up Integrations check out [our documentation on the Content API](/content-api/#authentication).
+For more detailed steps on setting up Integrations check out [our documentation on the Content API](/content-api/javascript/#authentication).
 
 You can remove the `@gridsome/source-filesystem` plugin if you’re not planning on using Markdown files for your content.
 

--- a/jamstack/hexo.mdx
+++ b/jamstack/hexo.mdx
@@ -60,7 +60,7 @@ Create a custom integration within Ghost Admin to generate a key and change the 
   <img src="/images/d3673af2-apikey_huc23d3a1fbe859434094a9db94f574d9a_265920_2920x0_resize_q100_h2_box_3.webp" />
 </Frame>
 
-For more detailed steps on setting up Integrations check out [our documentation on the Content API](/content-api/#authentication).
+For more detailed steps on setting up Integrations check out [our documentation on the Content API](/content-api/javascript/#authentication).
 
 ### The code
 
@@ -217,7 +217,7 @@ ghostAuthors();
 
 All the metadata that is exposed by the [Ghost Content API](/content-api/#endpoints) is available to use inside of a Hexo site. That includes post meta like authors and tags.
 
-In the example below the `posts.browse()` API options have been changed to include tags and authors which will be attached to each post object when it is returned. More information on the `include` API option can be found in our [Content API Endpoints](/content-api/#include) documentation.
+In the example below the `posts.browse()` API options have been changed to include tags and authors which will be attached to each post object when it is returned. More information on the `include` API option can be found in our [Content API parameters](/content-api/parameters/#include) documentation.
 
 ```js
 const data = await api.posts

--- a/jamstack/next.mdx
+++ b/jamstack/next.mdx
@@ -94,7 +94,7 @@ Create a custom integration within Ghost Admin to generate a key and change the 
   <img src="/images/d3673af2-apikey_huc23d3a1fbe859434094a9db94f574d9a_265920_2920x0_resize_q100_h2_box_3.webp" />
 </Frame>
 
-For more detailed steps on setting up Integrations check out [our documentation on the Content API](/content-api/#authentication).
+For more detailed steps on setting up Integrations check out [our documentation on the Content API](/content-api/javascript/#authentication).
 
 ### Exposing content
 

--- a/jamstack/nuxt.mdx
+++ b/jamstack/nuxt.mdx
@@ -63,7 +63,7 @@ Create a custom integration within Ghost Admin to generate a key and change the 
   <img src="/images/d3673af2-apikey_huc23d3a1fbe859434094a9db94f574d9a_265920_2920x0_resize_q100_h2_box_3.webp" />
 </Frame>
 
-For more detailed steps on setting up Integrations check out [our documentation on the Content API](/content-api/#authentication).
+For more detailed steps on setting up Integrations check out [our documentation on the Content API](/content-api/javascript/#authentication).
 
 ### Exposing content
 

--- a/jamstack/vuepress.mdx
+++ b/jamstack/vuepress.mdx
@@ -122,7 +122,7 @@ Next, update the `key` value to a key associated with the Ghost site. A key can 
   <img src="/images/d3673af2-apikey_huc23d3a1fbe859434094a9db94f574d9a_265920_2920x0_resize_q100_h2_box_3.webp" />
 </Frame>
 
-For more detailed steps on setting up Integrations check out [our documentation on the Content API](/content-api/#authentication).
+For more detailed steps on setting up Integrations check out [our documentation on the Content API](/content-api/javascript/#authentication).
 
 Let’s execute the script to fetch the Ghost content:
 

--- a/security.mdx
+++ b/security.mdx
@@ -95,7 +95,7 @@ We’re always interested in hearing about any reproducible vulnerability that a
 * Clickjacking with minimal security implications
 * Missing DMARC records
 
-**Privilege escalation attacks**
+#### Privilege escalation attacks
 
 Ghost is a content management system and all users are considered to be privileged/trusted. A user can only obtain an account and start creating content after they have been invited by the site owner or similar administrator-level user.
 

--- a/themes/contexts/author.mdx
+++ b/themes/contexts/author.mdx
@@ -9,7 +9,7 @@ Authors in Ghost each get their own page which outputs a list of posts that were
 
 ## Routes
 
-The default URL for author pages is `/author/:slug/`. The `author` context is also set on subsequent pages of the post list, which live at `/author/:slug/page/:num/`. The `slug` part of the URL is based on the name of the author and can be configured in admin. To change the author URL structure, use [routing](/themes/#routing).
+The default URL for author pages is `/author/:slug/`. The `author` context is also set on subsequent pages of the post list, which live at `/author/:slug/page/:num/`. The `slug` part of the URL is based on the name of the author and can be configured in admin. To change the author URL structure, use [routing](/themes/routing/#customising-taxonomies).
 
 ## Templates
 

--- a/themes/custom-settings.mdx
+++ b/themes/custom-settings.mdx
@@ -311,7 +311,7 @@ The only exception is when the theme **must** have text for a specific setting. 
 
 Configure setting dependencies to ensure that only relevant settings are displayed to the user in Ghost Admin. For example, a theme may offer several different header styles: `Landing`, `Highlight`, `Magazine`, `Search`, `Off`. If that value is `Landing` or `Search`, then an additional option becomes visible in Ghost Admin that allows the use of the publication’s cover image as the background. Otherwise, the option is hidden. By configuring setting dependencies, users get a better experience by only seeing settings that are relevant.
 
-To control when settings are visible, include the `visibility` key on the dependent setting. This key specifies the conditions that must be met for the setting to be displayed. Typically, you’ll specify the name of the parent setting and value it should have for the dependent setting to be visible. You can also use any [NQL syntax](/content-api/#filtering) for this — the same syntax used for filtering with the `get` helper.
+To control when settings are visible, include the `visibility` key on the dependent setting. This key specifies the conditions that must be met for the setting to be displayed. Typically, you’ll specify the name of the parent setting and value it should have for the dependent setting to be visible. You can also use any [NQL syntax](/content-api/filtering/#syntax-reference) for this — the same syntax used for filtering with the `get` helper.
 
 **Example: Header style and background image**
 

--- a/themes/helpers/data.mdx
+++ b/themes/helpers/data.mdx
@@ -10,7 +10,7 @@ description: Data helpers are used to output data from your site. Use this refer
 | [@custom](/themes/helpers/data/custom/)                          | Provides access to custom theme settings                             |
 | [@page](/themes/helpers/data/page/)                              | Provides access to page settings                                     |
 | [@site](/themes/helpers/data/site/)                              | Provides access to global settings                                   |
-| [@member](/themes/members/#the-member-object)               | Provides access to member data                                       |
+| [@member](/themes/members/#the-@member-object)              | Provides access to member data                                       |
 | [authors](/themes/helpers/data/authors/)                         | Outputs the post author(s)                                           |
 | [comments](/themes/helpers/data/comments/)                       | Outputs Ghost's member-based commenting system                       |
 | [content](/themes/helpers/data/content/)                         | Outputs the full post content as HTML                                |

--- a/themes/helpers/data/recommendations.mdx
+++ b/themes/helpers/data/recommendations.mdx
@@ -80,7 +80,7 @@ When the total number of recommendations exceeds the number defined in `limit`, 
 
 ### Filter
 
-Use logic-based queries to filter recommendations. For a guide to filtering syntax, see our [Content API docs](/content-api/#filtering).
+Use logic-based queries to filter recommendations. For a guide to filtering syntax, see our [Content API docs](/content-api/filtering/#syntax-reference).
 
 ```handlebars
 {{recommendations filter="favicon:-null"}}

--- a/themes/helpers/functional/get.mdx
+++ b/themes/helpers/functional/get.mdx
@@ -117,7 +117,7 @@ To output different content when there are no results returned from the `{{#get}
 
 ## Attributes
 
-Use `{{#get}}` helper attributes to specify which data is returned. Available attributes are identical to those used with the [Ghost Content API](/content-api/#parameters).
+Use `{{#get}}` helper attributes to specify which data is returned. Available attributes are identical to those used with the [Ghost Content API](/content-api/parameters/).
 
 “Browse” requests (fetching multiple items) accept any or all of these attributes. “Read” requests (fetching a single item by **id** or **slug**) only accept the **include** attribute.
 
@@ -275,7 +275,7 @@ Use `filter` to make complex, logic-based queries on the data to fetch. In its m
 {{/get}}
 ```
 
-Specify multiple rules for the `filter` attribute by using `,` for *or*, `+` for *and*, and `-` for *negation*. It’s possible to check for booleans, match against strings, look for items within a group, and much more. For a full breakdown of the filtering syntax and how to use it, please see the [filter documentation in the API docs](/content-api/#filtering).
+Specify multiple rules for the `filter` attribute by using `,` for *or*, `+` for *and*, and `-` for *negation*. It’s possible to check for booleans, match against strings, look for items within a group, and much more. For a full breakdown of the filtering syntax and how to use it, please see the [filter documentation in the API docs](/content-api/filtering/#syntax-reference).
 
 #### Passing data to `filter`
 

--- a/themes/routing.mdx
+++ b/themes/routing.mdx
@@ -171,7 +171,7 @@ collections:
     template: index
 ```
 
-Using an example from the previous section on [custom routes](/themes/routing/#routes), the home `/` route is now pointing at a static template called `home.hbs` — and the main collection has now been moved to load on `site.com/blog/`. Each post URL is also prefixed with `/blog/`.
+Using an example from the previous section on [custom routes](/themes/routing/#custom-routes), the home `/` route is now pointing at a static template called `home.hbs` — and the main collection has now been moved to load on `site.com/blog/`. Each post URL is also prefixed with `/blog/`.
 
 ***
 
@@ -219,7 +219,7 @@ Collections are an incredibly powerful way to organize your content and your sit
 
 #### Loading data into the index
 
-Much like [custom routes](/themes/routing/#routes), collections can also accept a data property in order to pass in the data to the collection’s index. For example, you might have a collection called `portfolio` which lists all of your most recent work. But how do you set the title, description, and metadata for *that* collection index?
+Much like [custom routes](/themes/routing/#custom-routes), collections can also accept a data property in order to pass in the data to the collection’s index. For example, you might have a collection called `portfolio` which lists all of your most recent work. But how do you set the title, description, and metadata for *that* collection index?
 
 ```yaml
 collections:
@@ -278,7 +278,7 @@ Each of these comes with its own automatically generated RSS feeds that are acce
 
 ### Customising taxonomies
 
-The configuration options for taxonomies are a lot more basic than [routes](/themes/routing/#routes) and [collections](/themes/routing/#collections). You can’t define new or custom taxonomies, you can only modify those which are already there and adapt their syntax a small amount.
+The configuration options for taxonomies are a lot more basic than [routes](/themes/routing/#custom-routes) and [collections](/themes/routing/#collections). You can’t define new or custom taxonomies, you can only modify those which are already there and adapt their syntax a small amount.
 
 ```yaml
 taxonomies:
@@ -315,7 +315,7 @@ Unlike [collections](/themes/routing/#collections), channels have no influence o
 
 ### Creating a channel
 
-Channels are defined as a [custom route](/themes/routing/#routes), with a custom `controller` property called `channel`, and a filter to determine which posts to return.
+Channels are defined as a [custom route](/themes/routing/#custom-routes), with a custom `controller` property called `channel`, and a filter to determine which posts to return.
 
 ```yaml
 routes:
@@ -373,7 +373,7 @@ If you’re still not sure which is the best fit for you, drop by the [Ghost For
 | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `template`     | Determines which Handlebars template file will be used for this route. Defaults to `index.hbs` if not specified.                                                                                                                                                                                                                                                                                                                                                             |
 | `permalink`    | The generated URL for any post within a collection. Can contain dynamic variables based on post data:<br/>• `{id}` - unique set of characters, eg. `5982d807bcf38100194efd67`<br/>• `{slug}` - the post slug, eg. `my-post`<br/>• `{year}` - publication year, eg. `2019`<br/>• `{month}` - publication month, eg. `04`<br/>• `{day}` - publication day, eg. `29`<br/>• `{primary_tag}` - slug of first tag listed in the post, eg. `news`<br/>• `{primary_author}` - slug of first author, eg. `cameron` |
-| `filter`       | Extensively filter posts returned in collections and channels using the full power and syntax of the [Ghost Content API](/content-api/#filtering) For example `author:cameron+tag:news` will return all posts published by Cameron, tagged with ‘News’. Mix and match to suit.                                                                                                                                                                                          |
+| `filter`       | Extensively filter posts returned in collections and channels using the full power and syntax of the [Ghost Content API](/content-api/filtering/#syntax-reference) For example `author:cameron+tag:news` will return all posts published by Cameron, tagged with ‘News’. Mix and match to suit.                                                                                                                                                                                          |
 | `order`        | Choose any number of fields and sort orders for your content:<br/>• `published_at desc` - *default*, newest post first<br/>• `published_at asc` - chronological, oldest first<br/>• `featured desc, published_at desc` - featured posts, then normal posts, newest first                                                                                                                                                                                                                  |
 | `data`         | Fetch & associate data from the Ghost API with a specified route. The source route of the data will be redirected to the new custom route.<br/>• `post.slug` - get data with => `{{#post}}`<br/>• `page.slug` - get data with => `{{#page}}`<br/>• `tag.slug` - get data with => `{{#tag}}`<br/>• `author.slug` - get data with => `{{#author}}`                                                                                                                                              |
 | `rss`          | Collections and channels come with automatically generated RSS feeds which can be disabled by setting the `rss` property to `false`                                                                                                                                                                                                                                                                                                                                          |


### PR DESCRIPTION
## Summary

- repair all 45 strict Mintlify anchor failures found across the documentation
- point references at the maintained authentication, filtering, parameter, routing, and troubleshooting sections
- promote existing content labels to headings where an addressable destination was missing
- preserve generated Mintlify fragments for the get helper and member object

## Verification

- mint validate --telemetry=false
- mint broken-links --telemetry=false
- mint broken-links --check-anchors --check-redirects --check-snippets --telemetry=false
- git diff --check
- independent developer and tidy-code review

## Follow-up

Accessibility remediation remains a separate audit slice: the current baseline is one dark-mode contrast failure and 96 missing-alt findings.