### PR TITLE
Add documentation validation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20.17.0
+      - name: Install Mint CLI
+        run: npm install --global mint@4.2.694
+      - name: Validate documentation
+        run: mint validate --telemetry=false
+      - name: Check links
+        run: mint broken-links --check-anchors --check-redirects --check-snippets --telemetry=false
+
+  required-checks-pass:
+    name: Required checks pass
+    if: always()
+    needs: [docs]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify all required jobs succeeded
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
+          echo "$NEEDS" | jq -e 'all(.[]; .result == "success")' > /dev/null


### PR DESCRIPTION
## Why

`main` has no repository-owned pull request validation. The Mintlify deployment check creates a preview, but it does not expose strict build, anchor, redirect, and snippet-link validation as a reproducible PR gate.

## What changed

- Added CI for pull requests and pushes to `main`.
- Pinned Node.js, the Mint CLI, and official actions for reproducibility.
- Added strict Mint build and internal-link validation.
- Added a fail-closed `Required checks pass` aggregator.
- Restricted workflow permissions to `contents: read`.

## Critical boundary map

- `docs.json` and MDX compilation: `mint validate`
- Internal document destinations: `mint broken-links`
- Heading anchors: `--check-anchors`
- Redirect destinations: `--check-redirects`
- Links in snippet components: `--check-snippets`
- Preview deployment: existing external `Mintlify Deployment` check

This repository documents Ghost APIs and CLI commands but does not implement an HTTP API, package API, CLI, worker, or release artifact.

## Trust classification

- Baseline: **Low** — no repository-owned PR CI.
- After merge: **Medium** — CI enforces the meaningful build and link boundaries.

High trust remains unmet because the static JSX components have no coverage harness and the rendered site has no automated browser or visual-regression assertion. The Mintlify preview remains available for human visual review.

## Verification

- `actionlint .github/workflows/ci.yml`
- `mint validate --telemetry=false`
- `mint broken-links --check-anchors --check-redirects --check-snippets --telemetry=false`

Both Mint checks pass with the exact workflow toolchain: Node.js `20.17.0` and Mint CLI `4.2.694`.

Coverage baseline/final: not measured; this content repository has no existing test harness. Third-party mocks: none. External URLs are not contacted by the link check.
