### PR TITLE
Add Renovate configuration

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -16,15 +16,6 @@
     ],
     packageRules: [
         {
-            description: "Keep CI pinned to Node 20.17.0 because it is the documented minimum supported runtime",
-            matchManagers: ["github-actions"],
-            matchDepTypes: ["uses-with"],
-            matchDepNames: ["node"],
-            matchPackageNames: ["actions/node-versions"],
-            matchCurrentValue: "20.17.0",
-            allowedVersions: "20.17.0",
-        },
-        {
             description: "Require manual review for Mint CLI updates because Mint defines documentation validation behavior",
             matchManagers: ["custom.regex"],
             matchPackageNames: ["mint"],

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,34 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    extends: ["local>TryGhost/renovate-config:safe"],
+    customManagers: [
+        {
+            customType: "regex",
+            description: "Update the Mint CLI version used by documentation CI",
+            managerFilePatterns: ["/^\\.github\\/workflows\\/ci\\.yml$/"],
+            matchStrings: [
+                "npm install --global mint@(?<currentValue>\\d+\\.\\d+\\.\\d+)",
+            ],
+            depNameTemplate: "mint",
+            datasourceTemplate: "npm",
+            versioningTemplate: "npm",
+        },
+    ],
+    packageRules: [
+        {
+            description: "Keep CI pinned to Node 20.17.0 because it is the documented minimum supported runtime",
+            matchManagers: ["github-actions"],
+            matchDepTypes: ["uses-with"],
+            matchDepNames: ["node"],
+            matchPackageNames: ["actions/node-versions"],
+            matchCurrentValue: "20.17.0",
+            allowedVersions: "20.17.0",
+        },
+        {
+            description: "Require manual review for Mint CLI updates because Mint defines documentation validation behavior",
+            matchManagers: ["custom.regex"],
+            matchPackageNames: ["mint"],
+            automerge: false,
+        },
+    ],
+}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    extends: ["local>TryGhost/renovate-config:safe"],
+    extends: ["local>TryGhost/renovate-config"],
     customManagers: [
         {
             customType: "regex",


### PR DESCRIPTION
## Why

Standardize dependency automation with the shared TryGhost Renovate policy now that this repository has reproducible PR validation and an enforced `Required checks pass` gate.

## What changed

- Added the root `renovate.json5` configuration.
- Extended the canonical `local>TryGhost/renovate-config` default preset.
- Added a narrowly scoped regex manager for the Mint CLI version in `.github/workflows/ci.yml`.
- Required manual review for Mint CLI updates.

## Preset decision

The repository-specific dependency surface is limited to the Mint CLI and GitHub Actions:

- Action updates execute the complete required CI path before merge.
- Mint updates execute build and strict link validation, and the local rule keeps them out of automerge for manual review.
- The fail-closed `Required checks pass` job is enforced by the active default-branch ruleset.

The default shared preset is therefore used by explicit repository-owner decision. CI is still classified as **Medium**, rather than High, because the rendered site has no automated browser or visual-regression assertion; that remaining gap is recorded rather than obscured.

## Configuration migration

- Previous config: none
- New config: root `renovate.json5`
- `package.json` Renovate key removed: not applicable; this repository has no `package.json`
- Existing overrides retained or dropped: none

## Local rules

- Mint: the regex manager extracts `mint@4.2.694` from the CI workflow. Updates are enabled but `automerge` is disabled because Mint defines documentation validation behavior.
- Node: no compatibility restriction is applied; the repository declares a minimum supported version, not a fixed runtime.
- Package manager: no constraint currently applies because the repository has no package manager.
- Action SHA pins: handled by Renovate's built-in GitHub Actions manager.

## Verification

- Renovate `43.262.3`: `renovate-config-validator --strict --no-global renovate.json5`
- Renovate extraction verified the Mint dependency identity and local rule.
- `git diff --check`
- `mint validate --telemetry=false`
- `mint broken-links --check-anchors --check-redirects --check-snippets --telemetry=false`
