### PR TITLE
Use active Node LTS in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20.17.0
+          node-version: lts/*
       - name: Install Mint CLI
         run: npm install --global mint@4.2.694
       - name: Validate documentation


### PR DESCRIPTION
## Why

The repository supports Node.js `20.17.0` or newer; that lower bound does not establish an exact runtime pin. CI should follow the active LTS release instead of freezing documentation validation to one patch version.

## What changed

- Changed the documentation workflow from exact Node `20.17.0` to `lts/*`.
- Kept the Mint CLI and action releases reproducibly pinned.

`lts/*` is a documented `actions/setup-node` version selector and is already used by other TryGhost workflows.

## Verification

- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- `mint validate --telemetry=false`
- `mint broken-links --check-anchors --check-redirects --check-snippets --telemetry=false`

Both Mint checks pass on the current official Node LTS, `24.18.0` (`Krypton`).
