### PR TITLE
Added Zenith to the cloud hosting options

### DIFF
--- a/install.mdx
+++ b/install.mdx
@@ -68,4 +68,11 @@ import { LocalInstallLogo } from '/snippets/local.jsx'
   >
     Virtual private servers
   </Card>
+  <Card
+    title="Zenith Hosting"
+    href="https://zenith.hosting/host/ghost"
+    icon="https://zenith.hosting/assets/logo.svg"
+  >
+    One-click managed instance
+  </Card>
 </CardGroup>


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Ghost to our marketplace, so this PR adds an entry to the "Cloud hosting" card group on the install page (links to https://zenith.hosting/host/ghost).

**Why are you making it?**

people who don't want to run a server, but also don't land on Ghost(Pro), currently have DigitalOcean and Linode on that page, both of which still leave them administering a VPS. this adds a managed option to the same list.

**What does it do?**

one card added to the existing `<CardGroup>` in `install.mdx`. no other files, no navigation changes, so `docs.json` is untouched. it uses a built-in icon rather than a new logo component, so nothing new is added to `snippets/`.

**Why is this something Ghost users or developers need?**

it's another route to a running Ghost site for non-technical publishers: storage, backups, TLS, updates and a free subdomain handled, or bring your own domain. we also share a cut of revenue with the projects we host, so Ghost earns from installs that come through it.

fully understand if you'd rather keep that list to Ghost(Pro) plus the VPS guides. happy to explain more if you're curious: hello@zenith.hosting

- [x] I've read and followed the [Contributor Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)
- [x] I've explained my change
- [ ] I've written an automated test to prove my change works (N/A, docs-only change)
