### PR TITLE
Updated self-hosting docs for Ubuntu 26

### DIFF
--- a/hosting.mdx
+++ b/hosting.mdx
@@ -58,9 +58,9 @@ Ghost has a [small team](/product/), so we optimize the software for a single, n
 
 To date, we've achieved this with our custom [Ghost-CLI](/install/ubuntu) install tool and the following officially supported and recommended stack:
 
-- Ubuntu 24
+- Ubuntu 22.04, 24.04 or 26.04 (LTS)
 - Node.js 22 LTS
-- MySQL 8.0
+- MySQL 8.0 or 8.4
 - NGINX
 - Systemd
 - A server with at least 1GB memory

--- a/install/linode.mdx
+++ b/install/linode.mdx
@@ -26,7 +26,7 @@ This part of the guide will ensure all prerequisites are met for installing the 
 
 ### Setup the server
 
-Follow the [official “Getting Started with Linode” guide](https://www.linode.com/docs/guides/getting-started/) to setup your server. You must choose the **Ubuntu image** when creating your server. As you’re creating a new server you should prefer Ubuntu version 22.04 LTS or version 24.04 LTS.
+Follow the [official “Getting Started with Linode” guide](https://www.linode.com/docs/guides/getting-started/) to setup your server. You must choose the **Ubuntu image** when creating your server. As you’re creating a new server you should prefer Ubuntu version 22.04 LTS, version 24.04 LTS or version 26.04 LTS.
 
 <Note>
    Note: Using the user name `ghost` causes conflicts with the Ghost-CLI, so it’s important to use an alternative name.

--- a/install/ubuntu.mdx
+++ b/install/ubuntu.mdx
@@ -1,13 +1,13 @@
 ---
 title: "How To Install Ghost On Ubuntu"
-description: "A full guide for installing, configuring and running Ghost on your Ubuntu **22.04** or **24.04** server, for use in production"
+description: "A full guide for installing, configuring and running Ghost on your Ubuntu **22.04**, **24.04** or **26.04** server, for use in production"
 ---
 
 ---
 
 ## Overview
 
-This the official guide for self-hosting Ghost using our recommended stack of Ubuntu 22.04 or 24.04. If you’re comfortable installing, maintaining and updating your own software, this is the place for you. By the end of this guide you’ll have a fully configured Ghost install running in production using MySQL.
+This the official guide for self-hosting Ghost using our recommended stack of Ubuntu 22.04, 24.04 or 26.04. If you’re comfortable installing, maintaining and updating your own software, this is the place for you. By the end of this guide you’ll have a fully configured Ghost install running in production using MySQL.
 
 This install is **not** suitable for [local use](/install/local/) or [contributing](/install/source/) to core.
 
@@ -21,10 +21,10 @@ To self-host web analytics or fully self-host the ActivityPub service, you will 
 
 The officially recommended production installation requires the following stack:
 
-- Ubuntu 22.04 or Ubuntu 24.04
+- Ubuntu 22.04, Ubuntu 24.04 or Ubuntu 26.04
 - NGINX (minimum of 1.9.5 for SSL)
 - A [supported version](/faq/node-versions/) of [Node.js](https://nodejs.org)
-- MySQL 8
+- MySQL 8.0 or 8.4
 - Systemd
 - A server with at least 1GB memory
 - A registered domain name
@@ -105,7 +105,7 @@ On newer versions of Ubuntu, the root user created when you install MySQL will b
 # Enter mysql
 sudo mysql
 # Update permissions
-ALTER USER 'root'@'localhost' IDENTIFIED WITH 'mysql_native_password' BY '<your-new-root-password>';
+ALTER USER 'root'@'localhost' IDENTIFIED WITH 'caching_sha2_password' BY '<your-new-root-password>';
 # Reread permissions
 FLUSH PRIVILEGES;
 # exit mysql


### PR DESCRIPTION
no ref
- add Ubuntu 26 to list of supported OSes
- update MySQL install instructions to use `caching_sha2_password`