### PR TITLE
Refresh contributing guide

### DIFF
--- a/contributing.mdx
+++ b/contributing.mdx
@@ -69,14 +69,6 @@ when you are ready to submit a change.
   >
     Answer questions, share what you have learned, and help other Ghost users.
   </Card>
-  <Card
-    title="Support Ghost"
-    icon="heart"
-    href="https://opencollective.com/ghost"
-  >
-    Fund the non-profit Ghost Foundation and the continued development of open
-    source publishing software.
-  </Card>
 </CardGroup>
 
 ## Community guidelines
@@ -90,3 +82,27 @@ feedback.
 For help using Ghost, ask on the [forum](https://forum.ghost.org/) rather than
 opening a GitHub issue. GitHub issues are reserved for confirmed bugs and
 agreed development work.
+
+## Donations
+
+Ghost is an independent non-profit organisation. Donations help the Ghost
+Foundation employ people to build and maintain free, open source publishing
+software.
+
+<CardGroup cols={2}>
+  <Card
+    title="Open Collective"
+    icon="heart"
+    href="https://opencollective.com/ghost"
+  >
+    Support Ghost through a one-time or recurring donation.
+  </Card>
+  <Card
+    title="Partnerships"
+    icon="handshake"
+    href="https://ghost.org/partners/"
+  >
+    Learn about supporting Ghost with products, services, or other partnership
+    opportunities.
+  </Card>
+</CardGroup>

--- a/contributing.mdx
+++ b/contributing.mdx
@@ -92,24 +92,23 @@ before using the Ghost name or logo in your project.
 
 ## Donations
 
-Ghost is an independent non-profit organisation. Donations help the Ghost
-Foundation employ people to build and maintain free, open source publishing
-software.
+As a non-profit organisation we’re always grateful to receive any and all donations to help our work, and allow us to employ more people to work on Ghost directly.
 
-<CardGroup cols={2}>
-  <Card
-    title="Open Collective"
-    icon="heart"
-    href="https://opencollective.com/ghost"
-  >
-    Support Ghost through a one-time or recurring donation.
-  </Card>
-  <Card
-    title="Partnerships"
-    icon="handshake"
-    href="https://ghost.org/partners/"
-  >
-    Learn about supporting Ghost with products, services, or other partnership
-    opportunities.
-  </Card>
-</CardGroup>
+#### Partnerships
+
+We’re very [happy to partner](https://ghost.org/partners/) with startups and companies who are able to provide Ghost with credit, goods and services which help us build free, open software for everyone. Please reach out to us `hello@ghost.org` if you’re interested in partnering with us to help Ghost.
+
+#### Open Collective
+
+We have a number of ongoing donation and sponsorship opportunities for individuals or companies looking to make ongoing contributions to the open source software which they use on [Open Collective](https://opencollective.com/ghost).
+
+#### Bitcoin
+
+For those who prefer to make a one time donation, we’re very happy to accept BTC. Unless you explicitly want your donation to be anonymous, please send us a tweet or an email and let us know who you are! We’d love to say thank you.
+
+<Frame>
+  <img src="/images/c60e8c5b-btc-wallet_huc4fe22c23acec5bcf43cd862bd3a3a9a_3915_356x0_resize_q100_h2_box_3.webp" />
+</Frame>
+
+**Ghost BTC Address:**\
+`3CrQfpWaZPFfD4kAT7kh6avbW7bGBHiBq9`

--- a/contributing.mdx
+++ b/contributing.mdx
@@ -83,6 +83,13 @@ For help using Ghost, ask on the [forum](https://forum.ghost.org/) rather than
 opening a GitHub issue. GitHub issues are reserved for confirmed bugs and
 agreed development work.
 
+## Ghost trademark
+
+**Ghost** is a registered trademark of Ghost Foundation Ltd. We offer a
+flexible trademark usage licence for community projects, companies, and
+individuals. Read the [Ghost trademark usage policy](https://ghost.org/trademark/)
+before using the Ghost name or logo in your project.
+
 ## Donations
 
 Ghost is an independent non-profit organisation. Donations help the Ghost

--- a/contributing.mdx
+++ b/contributing.mdx
@@ -1,84 +1,92 @@
 ---
-title: "Contributing To Ghost"
+title: "Contributing to Ghost"
 sidebarTitle: "Contributing"
-description: Ghost is completely open source software built almost entirely by volunteer contributors who use it every day.
+description: Help improve Ghost through code, documentation, translations, testing, and community support.
 ---
 
-***
+Ghost is free and open source software maintained by the Ghost Foundation and
+contributors from around the world. Whether you want to fix a bug, improve the
+documentation, translate Ghost, or help another user, there is a place to get
+involved.
 
-The best part about structuring a software project this way is that not only does everyone get to own the source code without restriction, but as people all over the world help to improve it: Everyone benefits.
+## Contribute to the Ghost codebase
 
-## Core team
+If you are looking for a first code contribution, browse the
+[good first issues](https://github.com/TryGhost/Ghost/labels/good%20first%20issue).
+The broader [help wanted](https://github.com/TryGhost/Ghost/labels/help%20wanted)
+list contains work where community contributions are especially welcome.
 
-In addition to [full time product team](https://ghost.org/about/) working for Ghost Foundation, there are a number of community members who have contributed to the project for a lengthy period of time and are considered part of the core team. They are:
+Before starting a new feature or a substantial product or architecture change,
+discuss the idea on the [Ghost Forum](https://forum.ghost.org/) so that the
+approach can be agreed before implementation.
 
-* [Austin Burdine](https://github.com/acburdine) - Ghost-CLI
-* [Felix Rieseberg](https://github.com/felixrieseberg) - Ghost Desktop
-* [Vicky Chijwani](https://github.com/vickychijwani) - Ghost Mobile
-* [David Balderston](https://github.com/dbalders) - Community
+<CardGroup cols={2}>
+  <Card
+    title="Contribution requirements"
+    icon="code-pull-request"
+    href="https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md"
+  >
+    Read the contribution contract, pull request expectations, commit message
+    conventions, and Contributor License Agreement.
+  </Card>
+  <Card
+    title="Codebase documentation"
+    icon="book-open"
+    href="https://github.com/TryGhost/Ghost/tree/main/docs"
+  >
+    Set up the monorepo, understand its structure, choose the right tests, and
+    follow the current development workflow.
+  </Card>
+</CardGroup>
 
-#### How core team members are added
+The repository documentation is the source of truth for working on Ghost. Start
+with the [development setup guide](https://github.com/TryGhost/Ghost/blob/main/docs/contributing/development-setup.md),
+then use the [contribution workflow](https://github.com/TryGhost/Ghost/blob/main/docs/contributing/workflow.md)
+when you are ready to submit a change.
 
-People typically invited to join the Core Team officially after an extended period of successful contribution to Ghost and demonstrating good judgement. In particular, this means having humility, being open to feedback and changing their mind, knowing the limits of their abilities and being able to communicate all of these things such that it is noticed. Good judgement is what produces trust, not quality, quantity or pure technical skill.
+## Other ways to contribute
 
-When we believe a core contributor would make a great ambassador for Ghost and feel able to trust them to make good decisions about its future - that’s generally when we’ll ask them to become a member of the formal Core Team.
-
-Core Team members are granted commit rights to Ghost projects, access to the Ghost Foundation private Slack, and occasionally join our international team retreats.
+<CardGroup cols={2}>
+  <Card
+    title="Translate Ghost"
+    icon="language"
+    href="https://github.com/TryGhost/Ghost/blob/main/docs/contributing/translating-ghost.md"
+  >
+    Help make Ghost available in more languages through the supported
+    translation workflow.
+  </Card>
+  <Card
+    title="Improve these docs"
+    icon="file-lines"
+    href="https://github.com/TryGhost/Docs/blob/main/.github/CONTRIBUTING.md"
+  >
+    Correct or expand the developer documentation published on this site.
+  </Card>
+  <Card
+    title="Help in the community"
+    icon="comments"
+    href="https://forum.ghost.org/"
+  >
+    Answer questions, share what you have learned, and help other Ghost users.
+  </Card>
+  <Card
+    title="Support Ghost"
+    icon="heart"
+    href="https://opencollective.com/ghost"
+  >
+    Fund the non-profit Ghost Foundation and the continued development of open
+    source publishing software.
+  </Card>
+</CardGroup>
 
 ## Community guidelines
 
-All participation in the Ghost community is subject to our incredibly straightforward [code of conduct](https://ghost.org/conduct/) and wider [community guidelines](https://forum.ghost.org/t/faq-guidelines/5).
+All participation in the Ghost community is subject to our
+[Code of Conduct](https://ghost.org/conduct/) and
+[forum guidelines](https://forum.ghost.org/t/faq-guidelines/5). Be kind,
+participate constructively, and assume good intent when giving or receiving
+feedback.
 
-The vast majority of the Ghost community is incredible, and we work hard to make sure it stays that way. We always welcome people who are friendly and participate constructively, but we outright ban anyone who is behaving in a poisonous manner.
-
-## Ghost Trademark
-
-**Ghost** is a registered trademark of Ghost Foundation Ltd. We’re happy to extend a flexible usage license of the Ghost trademark to community projects, companies and individuals, however it please read the **[Ghost trademark usage policy](https://ghost.org/trademark/)** before using the Ghost name in your project.
-
-## Development guide
-
-If you’re a developer looking to help, but you’re not sure where to begin: Check out the [good first issue](https://github.com/TryGhost/Ghost/labels/good%20first%20issue) label on GitHub, which contains small pieces of work that have been specifically flagged as being friendly to new contributors.
-
-Or, if you’re looking for something a little more challenging to sink your teeth into, there’s a broader [help wanted](https://github.com/TryGhost/Ghost/labels/help%20wanted) label encompassing issues which need some love.
-
-When you’re ready, check out the full **[Ghost Contributing Guide](https://github.com/TryGhost/Ghost/blob/main/.github/CONTRIBUTING.md)** for detailed instructions about how to hack on Ghost Core and send changes upstream.
-
-<Note>
-Ghost is currently hiring Product Engineers! Check out what it’s like to be part of the team and see our open roles at [careers.ghost.org](https://careers.ghost.org/)
-
-</Note>
-
-## Other ways to help
-
-The primary way to contribute to Ghost is by writing code, but if you’re not a developer there are still ways you can help. We always need help with:
-
-* Helping our Ghost users on [the forum](https://forum.ghost.org)
-* Creating tutorials and guides
-* Testing and quality assurance
-* Hosting local events or meetups
-* Promoting Ghost to others
-
-There are lots of ways to make discovering and using Ghost a better experience.
-
-## Donations
-
-As a non-profit organisation we’re always grateful to receive any and all donations to help our work, and allow us to employ more people to work on Ghost directly.
-
-#### Partnerships
-
-We’re very [happy to partner](https://ghost.org/partners/) with startups and companies who are able to provide Ghost with credit, goods and services which help us build free, open software for everyone. Please reach out to us `hello@ghost.org` if you’re interested in partnering with us to help Ghost.
-
-#### Open Collective 
-
-**New:** We have a number of ongoing donation and sponsorship opportunities for individuals or companies looking to make ongoing contributions to the open source software which they use on [Open Collective](https://opencollective.com/ghost).
-
-#### Bitcoin
-
-For those who prefer to make a one time donation, we’re very happy to accept BTC. Unless you explicitly want your donation to be anonymous, please send us a tweet or an email and let us know who you are! We’d love to say thank you.
-
-<Frame>
-  <img src="/images/c60e8c5b-btc-wallet_huc4fe22c23acec5bcf43cd862bd3a3a9a_3915_356x0_resize_q100_h2_box_3.webp" />
-</Frame>
-
-**Ghost BTC Address:**\
-`3CrQfpWaZPFfD4kAT7kh6avbW7bGBHiBq9`
+For help using Ghost, ask on the [forum](https://forum.ghost.org/) rather than
+opening a GitHub issue. GitHub issues are reserved for confirmed bugs and
+agreed development work.


### PR DESCRIPTION
## Summary

- Replaces outdated team, hiring, and donation details with current ways to contribute to Ghost.
- Directs code contributors to the canonical contribution contract and codebase documentation in the Ghost repository.
- Makes translation, documentation, community support, and funding routes easier to find.

## Testing

- [x] `pnpm lint`
- [x] `pnpm test:validate`
- [x] `pnpm test:links`
- [x] Manual preview at `/contributing`
